### PR TITLE
Fix pluck

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -24,10 +24,7 @@ function loadModules(root, depType) {
             });
           }).catch(function (e) {
             if (e.code === 'NO_PACKAGE_FOUND') {
-              return {
-                name: name,
-                version: tree.__dependencies[name],
-              };
+              return false;
             }
           }));
         }
@@ -36,7 +33,7 @@ function loadModules(root, depType) {
 
     if (missing.length) {
       return Promise.all(missing).then(function (packages) {
-        packages.forEach(function (pkg) {
+        packages.filter(Boolean).forEach(function (pkg) {
           pkg.dep = tree.__dependencies[pkg.name];
           tree.dependencies[pkg.name] = pkg;
         });
@@ -199,7 +196,7 @@ function loadModulesInternal(root, rootDepType, parent) {
       /* istanbul ignore else  */
       if (error.code === 'ENOENT') {
         // there's no node_modules directory, that's fine, there's no deps
-        modules.dependencies = false;
+        modules.dependencies = {};
         return modules;
       }
 

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -98,8 +98,11 @@ function problem(root, issue) {
 
 function walkDeps(root, tree) {
   // only include the devDeps on the root level package
-  var deps = _.extend({}, tree.__dependencies, tree.__from.length === 1 ?
-    tree.__devDependencies : {});
+  if (!tree.__from) {
+    debugger;
+  }
+  var deps = _.extend({}, tree.__dependencies,
+    tree.__from && tree.__from.length === 1 ? tree.__devDependencies : {});
   return Object.keys(deps).reduce(function walkDepsPicker(acc, curr) {
     var version = deps[curr];
     var dep = pluck(root, tree.__from, curr, version);

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -36,24 +36,40 @@ function logicalTree(fileTree, options) {
     logicalRoot.problems = fileTree.problems.slice(0);
   }
 
-  walk(fileTree.dependencies, function (dep) {
+  var removedPaths = [];
+
+  // do a shallow pass on the deps and strip out dev deps
+  Object.keys(fileTree.dependencies).forEach(function (name) {
+    var dep = fileTree.dependencies[name];
     // if we're not interested in devDeps, then strip them out
-    // debugger;
     if (!options.dev && dep.depType === depTypes.DEV) {
       // since dev deps are only ever on the root, we know we can remove it
       // directly from the logicalRoot.dependencies
+      removedPaths.push(dep.__from);
       delete logicalRoot.dependencies[dep.name];
       return;
     }
+  });
 
+
+  walk(fileTree.dependencies, function (dep) {
     if (!dep.__used) {
+      var deppath = dep.__from.slice(0, -1).toString();
+      var removed = removedPaths.filter(function (path) {
+        return deppath.indexOf(path) === 0;
+      }).length;
+
+      if (removed) {
+        return false; // this was from a dev dep, so let's lose it
+      }
+
       dep.extraneous = true;
       dep.depType = depTypes.EXTRANEOUS;
-      var issue = ext + ': ' + (dep.__from || []).join(' > ') +
-          ' > ' + dep.full;
+      var issue = ext + ': ' + dep.name + '@' + dep.version + ' (from ' +
+        dep.dep + ') > ' + dep.__filename;
       dep.problems = [issue];
       problem(logicalRoot, issue);
-      insertLeaf(logicalRoot, dep);
+      insertLeaf(logicalRoot, dep, fileTree);
     }
   });
 
@@ -66,7 +82,9 @@ function insertLeaf(tree, leaf) {
   var path = (leaf.__from || []).slice(1, -1); // remove the root of the path
   var entry = tree.dependencies;
   for (var i = 0; i < path.length; i++) {
-    entry = entry[path[i]].dependencies;
+    if (entry[path[i]]) {
+      entry = entry[path[i]].dependencies;
+    }
   }
   entry[leaf.name] = leaf;
 }

--- a/lib/pluck.js
+++ b/lib/pluck.js
@@ -7,6 +7,10 @@ var debug = require('debug')('snyk:resolve:pluck');
 function pluck(root, path, name, range) {
   debug('plucking %s@%s', name, range);
 
+  if (range === 'latest') {
+    range = '*';
+  }
+
   // Cycle through the tree path via the root tree object **ala node require**.
   // note that we don't need the first item in the path (which is the root
   // package name).

--- a/lib/pluck.js
+++ b/lib/pluck.js
@@ -10,54 +10,57 @@ function pluck(root, path, name, range) {
   // Cycle through the tree path via the root tree object **ala node require**.
   // note that we don't need the first item in the path (which is the root
   // package name).
-  var rootPath = moduleToObject(path[0]).name;
+  var from = path.slice(0);
+  var rootPath = moduleToObject(from.shift()).name;
 
+  // if the root of the virtual tree doesn't even match our path, bail out
   if (rootPath !== root.name) {
     return false;
   }
 
-  // make a copy (in case it's an important ref)
-  var from = path.map(stripVersion).slice(1);
-  var deps = false;
-  var leaf = false;
-  var match = false;
-
-  leaf = root;
-  var position = 0;
-  var leafStack = [root];
-
-  if (from.length === 0) {
-    return getMatch(getDependency(root, name), range);
-  }
-
-  do {
-    deps = getDependency(leaf, from[position]);
-
-    if (deps) {
-      match = getMatch(getDependency(deps, name), range);
-      if (match) {
-        return match; // break
-      }
-
-      // store the old leaf
-      leafStack.push(leaf);
-
-      // and move forward
-      leaf = deps;
-    } else {
-      // rewind back through the leaves
-      position--;
-      leaf = leafStack.pop();
+  // do a check to see if the last item in the path is actually the package
+  // we're looking for, and if it is, drop it
+  if (from.length) {
+    var tip = moduleToObject(from.slice(-1).pop());
+    // note: this could miss the situation when dep@2 > dep@1 ...unsure
+    if (tip.name === name) {
+      from.pop();
     }
-
-    position++;
-  } while (position < from.length);
-
-  // handle the case where the found package is at the very root
-  if (getDependency(root, name)) {
-    return getMatch(root.dependencies[name], range);
   }
 
+  // strip any extraneous data from the package names
+  from = from.map(stripVersion);
+
+  // walk the depth of `from` to find the `dependencies` property from `root`
+  // if it can't be found, pop `from` and try again until `from` is empty
+  do {
+    var pkg = findPackage(root, from, name, range);
+
+    if (pkg) {
+      return pkg;
+    }
+  } while (from.pop());
+
+  return false;
+}
+
+function findPackage(root, from, name, range) {
+  var deps;
+  do {
+    deps = from.reduce(findDependencyLeaf, root);
+  } while (!deps && from.shift());
+
+  var match = getMatch(deps, name, range);
+
+  if (match) {
+    return match;
+  }
+}
+
+function findDependencyLeaf(acc, curr) {
+  if (acc.dependencies && acc.dependencies[curr]) {
+    return acc.dependencies[curr];
+  }
   return false;
 }
 
@@ -66,10 +69,12 @@ function stripVersion(value) {
   return moduleToObject(value).name;
 }
 
-function getMatch(dep, range) {
+function getMatch(root, name, range) {
+  var dep = root.dependencies && root.dependencies[name];
   if (!dep) {
     return false;
   }
+
   var version = dep.version;
   debug('pluck match on name...checking version: %s ~= %s', version, range);
   // make sure it matches our range
@@ -89,12 +94,4 @@ function getMatch(dep, range) {
   }
 
   return false;
-}
-
-function getDependency(leaf, name) {
-  if (!leaf || !leaf.dependencies) {
-    return null;
-  }
-
-  return leaf.dependencies[name] || null;
 }

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -22,10 +22,15 @@ test('end to end (no deps but has node_modules)', function (t) {
   .then(t.end);
 });
 
-test('end to end (this package)', function (t) {
+test('end to end (this package with dev)', function (t) {
   lib(__dirname + '/../', { dev: true })
   .then(function (res) {
     var fixtures = res.dependencies['snyk-resolve-deps-fixtures'];
+    var from = ['snyk-resolve-deps', 'tap', 'nyc', 'istanbul', 'handlebars', 'uglify-js', 'source-map'];
+    var plucked = res.pluck(from, 'source-map', '~0.5.1');
+
+    t.notOk(res.dependencies.tap.dependencies.nyc.dependencies.istanbul.dependencies.handlebars.dependencies['uglify-js'].dependencies['source-map'].extraneous, 'source-map is not extraneous');
+
     t.ok(fixtures, 'has the fixtures dep');
     t.equal(fixtures.dependencies['@remy/npm-tree'].name, '@remy/npm-tree', 'has npm-tree');
     t.equal(fixtures.dependencies['@remy/vuln-test'].name, '@remy/vuln-test', 'has vuln-test');
@@ -34,6 +39,19 @@ test('end to end (this package)', function (t) {
     var plucked = res.pluck(['snyk-resolve-deps@1', 'snyk-resolve-deps-fixtures@1', '@remy/npm-tree'], '@remy/npm-tree', '*');
     t.equal(plucked.name, '@remy/npm-tree');
     t.ok(plucked.__filename, 'got __filename');
+  })
+  .catch(t.threw)
+  .then(t.end);
+});
+
+test('end to end (this package __without__ dev)', function (t) {
+  lib(__dirname + '/../')
+  .then(function (res) {
+    var from = ['snyk-resolve-deps', 'tap', 'nyc', 'istanbul', 'handlebars', 'uglify-js', 'source-map'];
+    var plucked = res.pluck(from, 'source-map', '~0.5.1');
+    t.ok(plucked.name, 'source-map');
+    // t.notOk(res.dependencies.tap.dependencies.nyc.dependencies.istanbul.dependencies.handlebars.dependencies['uglify-js'].dependencies['source-map'].extraneous, 'source-map is not extraneous');
+
   })
   .catch(t.threw)
   .then(t.end);

--- a/test/pluck.test.js
+++ b/test/pluck.test.js
@@ -83,6 +83,13 @@ function pluckTests(t, res) {
     t.equal(plucked.name, 'semver', 'found on a straight path');
   }
 
+  if (res.npm === 2) {
+    from = ['snyk-resolve-deps', 'tap', 'nyc', 'istanbul', 'handlebars', 'uglify-js', 'source-map'];
+    plucked = pluck(res, from, 'source-map', '~0.5.1');
+    t.equal(plucked.name, 'source-map', 'found on a straight path');
+    t.notOk(plucked.extraneous, 'not extraneous');
+  }
+
   from = [
     'snyk-resolve-deps',
     'snyk-resolve-deps-fixtures',


### PR DESCRIPTION
There was an edge case in npm@2 packages where it would pluck the package early from the tree, leaving part of the tree as extraneous.

This change refactors pluck.js (again...) to handle more cases.
