### PR TITLE
fix: deduped logical tree resolution

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -48,7 +48,8 @@ Promise.resolve().then(function () {
           });
           console.log('%s %s@%s', count.length, match.name, match.version);
           count.forEach(function (dep) {
-            console.log(' - %s - %s', dep.full, (dep.from || []).join(' > '));
+            console.log(' - %s (%s) - %s', dep.full, dep.depType,
+              (dep.from || []).join(' > '));
           });
           return;
         }

--- a/cli/index.js
+++ b/cli/index.js
@@ -48,7 +48,7 @@ Promise.resolve().then(function () {
           });
           console.log('%s %s@%s', count.length, match.name, match.version);
           count.forEach(function (dep) {
-            console.log(' - %s - %s', dep.full, dep.from.join(' > '));
+            console.log(' - %s - %s', dep.full, (dep.from || []).join(' > '));
           });
           return;
         }

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -1,8 +1,0 @@
-// Dependency types.
-// We don't call out all of them, only the ones relevant to our behavior.
-// extraneous means not found in package.json files, prod means not dev ATM
-module.exports = {
-  EXTRANEOUS: 'extraneous',
-  PROD: 'prod',
-  DEV: 'dev',
-};

--- a/lib/dep-types.js
+++ b/lib/dep-types.js
@@ -5,11 +5,6 @@ var depTypes = module.exports = function (depName, pkg) {
   var type = null;
   var from = 'unknown';
 
-  if (pkg.dependencies && pkg.dependencies[depName]) {
-    type = depTypes.PROD;
-    from = pkg.dependencies[depName];
-  }
-
   if (pkg.devDependencies && pkg.devDependencies[depName]) {
     type = depTypes.DEV;
     from = pkg.devDependencies[depName];
@@ -18,6 +13,12 @@ var depTypes = module.exports = function (depName, pkg) {
   if (pkg.optionalDependencies && pkg.optionalDependencies[depName]) {
     type = depTypes.OPTIONAL;
     from = pkg.optionalDependencies[depName];
+  }
+
+  // production deps trump all
+  if (pkg.dependencies && pkg.dependencies[depName]) {
+    type = depTypes.PROD;
+    from = pkg.dependencies[depName];
   }
 
   return {

--- a/lib/dep-types.js
+++ b/lib/dep-types.js
@@ -1,0 +1,32 @@
+// Dependency types.
+// We don't call out all of them, only the ones relevant to our behavior.
+// extraneous means not found in package.json files, prod means not dev ATM
+var depTypes = module.exports = function (depName, pkg) {
+  var type = null;
+  var from = 'unknown';
+
+  if (pkg.dependencies && pkg.dependencies[depName]) {
+    type = depTypes.PROD;
+    from = pkg.dependencies[depName];
+  }
+
+  if (pkg.devDependencies && pkg.devDependencies[depName]) {
+    type = depTypes.DEV;
+    from = pkg.devDependencies[depName];
+  }
+
+  if (pkg.optionalDependencies && pkg.optionalDependencies[depName]) {
+    type = depTypes.OPTIONAL;
+    from = pkg.optionalDependencies[depName];
+  }
+
+  return {
+    type: type,
+    from: from,
+  };
+};
+
+module.exports.EXTRANEOUS = 'extraneous';
+module.exports.OPTIONAL = 'optional';
+module.exports.PROD = 'prod';
+module.exports.DEV = 'dev';

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -1,6 +1,6 @@
 module.exports = loadModules;
 
-var depTypes = require('./consts');
+var depTypes = require('./dep-types');
 var fs = require('then-fs');
 var _ = require('lodash');
 var debug = require('debug')('snyk:resolve:deps');
@@ -71,6 +71,7 @@ function loadModulesInternal(root, rootDepType, parent) {
         __from: (parent || { __from: [] }).__from,
         __devDependencies: pkg.devDependencies,
         __dependencies: pkg.dependencies,
+        __optionalDependencies: pkg.optionalDependencies,
         __filename: pkg.__filename,
       };
 
@@ -132,21 +133,14 @@ function loadModulesInternal(root, rootDepType, parent) {
             license = (licenses || {}).type || licenses;
           }
 
-          var depType = rootDepType;
-          if (pkg.dependencies && pkg.dependencies[curr.name]) {
-            depType = depTypes.PROD;
-          } else if (pkg.devDependencies && pkg.devDependencies[curr.name]) {
-            depType = depTypes.DEV;
-          }
+          var depInfo = depTypes(curr.name, pkg);
+          var depType = depInfo.type || rootDepType;
+          var depFrom = depInfo.from;
 
           var valid = false;
-          if (pkg.dependencies) {
-            valid = semver.satisfies(curr.version, pkg.dependencies[curr.name]);
+          if (depFrom) {
+            valid = semver.satisfies(curr.version, depFrom);
           }
-
-          var depFrom = depType === depTypes.DEV ?
-            pkg.devDependencies[curr.name] :
-            pkg.dependencies[curr.name];
 
           acc[curr.name] = {
             name: curr.name,
@@ -160,6 +154,7 @@ function loadModulesInternal(root, rootDepType, parent) {
             __from: pkg.__from.concat(curr.name),
             __devDependencies: curr.devDependencies,
             __dependencies: curr.dependencies,
+            __optionalDependencies: curr.optionalDependencies,
             __filename: curr.__filename,
           };
           return acc;
@@ -169,13 +164,6 @@ function loadModulesInternal(root, rootDepType, parent) {
       });
     }).then(function (modules) {
       var deps = Object.keys(modules.dependencies);
-
-      // TODO decide if we can really remove this - I can't see how it's ever
-      // called in real life...
-      // if (deps.length === 0) {
-      //   modules.dependencies = false;
-      //   return modules;
-      // }
 
       var promises = deps.map(function (dep) {
         var depType = modules.dependencies[dep].depType;

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -3,10 +3,13 @@ module.exports = logicalTree;
 var Promise = require('es6-promise').Promise; // jshint ignore:line
 var pluck = require('./pluck');
 var walk = require('./walk');
+var path = require('path');
 var depTypes = require('./consts');
 var colour = require('ansicolors');
 var _ = require('lodash');
+var format = require('util').format;
 var ext = colour.bgBlack(colour.green('extraneous'));
+var problems = [];
 
 /**
  * This code will build up the logical tree representation of a node package
@@ -30,11 +33,10 @@ function logicalTree(fileTree, options) {
   if (!options) {
     options = {};
   }
-  var logicalRoot = copy(fileTree);
+
+  problems = [];
+  var logicalRoot = copy(fileTree, fileTree.__from, true);
   logicalRoot.dependencies = walkDeps(fileTree, fileTree);
-  if (fileTree.problems && fileTree.problems.length) {
-    logicalRoot.problems = fileTree.problems.slice(0);
-  }
 
   var removedPaths = [];
 
@@ -51,7 +53,6 @@ function logicalTree(fileTree, options) {
     }
   });
 
-
   walk(fileTree.dependencies, function (dep) {
     if (!dep.__used) {
       var deppath = dep.__from.slice(0, -1).toString();
@@ -63,23 +64,27 @@ function logicalTree(fileTree, options) {
         return false; // this was from a dev dep, so let's lose it
       }
 
-      dep.extraneous = true;
-      dep.depType = depTypes.EXTRANEOUS;
-      var issue = ext + ': ' + dep.name + '@' + dep.version + ' (from ' +
-        dep.dep + ') > ' + dep.__filename;
-      dep.problems = [issue];
-      problem(logicalRoot, issue);
-      insertLeaf(logicalRoot, dep, fileTree);
+      var leaf = copy(dep);
+
+      var issue = format('%s: %s@%s (from %s) > %s', ext, leaf.name,
+        leaf.version, leaf.dep, path.relative('.', leaf.__filename));
+      leaf.problems = [issue];
+      problems.push(issue);
+      leaf.extraneous = true;
+      leaf.depType = depTypes.EXTRANEOUS;
+      leaf.dependencies = walkDeps(fileTree, dep);
+      insertLeaf(logicalRoot, leaf, dep.__from);
     }
   });
 
   logicalRoot.pluck = pluck.bind(null, fileTree);
+  logicalRoot.problems = problems.slice(0);
 
   return logicalRoot;
 }
 
-function insertLeaf(tree, leaf) {
-  var path = (leaf.__from || []).slice(1, -1); // remove the root of the path
+function insertLeaf(tree, leaf, from) {
+  var path = (from || []).slice(1, -1); // remove the root of the path
   var entry = tree.dependencies;
   for (var i = 0; i < path.length; i++) {
     if (entry[path[i]]) {
@@ -89,44 +94,54 @@ function insertLeaf(tree, leaf) {
   entry[leaf.name] = leaf;
 }
 
-function problem(root, issue) {
-  if (!root.problems) {
-    root.problems = [];
+function walkDeps(root, tree, from) {
+  if (!from) {
+    from = tree.__from;
   }
-  root.problems.push(issue);
-}
 
-function walkDeps(root, tree) {
   // only include the devDeps on the root level package
   var deps = _.extend({}, tree.__dependencies,
-    tree.__from && tree.__from.length === 1 ? tree.__devDependencies : {});
+    tree.__from && from.length === 1 ? tree.__devDependencies : {});
+
   return Object.keys(deps).reduce(function walkDepsPicker(acc, curr) {
-    var version = deps[curr];
-    var dep = pluck(root, tree.__from, curr, version);
+    // only attempt to walk this dep if it's not in our path already
+    if (tree.__from.indexOf(curr) === -1) {
+      var version = deps[curr];
+      var dep = pluck(root, tree.__from, curr, version);
 
-    if (!dep) {
-      problem(root, 'missing: ' + curr + '@' + version +
-              ', required by ' + tree.name + '@' + tree.version);
-      return acc;
-    }
+      if (!dep) {
+        problems.push(format('missing: %s@%s, required by %s', curr, version,
+          from.join(' > ')));
+        return acc;
+      }
 
-    var pkg = acc[dep.name] = copy(dep, tree.__from.concat(dep.name));
-    if (!dep.__used) {
-      dep.__used = true;
-      pkg.dependencies = walkDeps(root, dep);
+      if (from.indexOf(dep.name) === -1) {
+        var pkg = acc[dep.name] = copy(dep, from.concat(dep.name));
+        dep.__used = true;
+        pkg.dependencies = walkDeps(root, dep, pkg.from);
+      }
     }
 
     return acc;
   }, {});
 }
 
-function copy(leaf, from) {
+function copy(leaf, from, ignoreDeps) {
+  if (!from) {
+    from = leaf.__from;
+  }
+
   var res = Object.keys(leaf).reduce(function copyIterator(acc, curr) {
     if (leaf[curr] !== undefined && curr.indexOf('__') !== 0) {
-      acc[curr] = leaf[curr];
+      if (curr !== 'dependencies') {
+        acc[curr] = leaf[curr];
+      }
     }
     return acc;
   }, {});
-  res.from = (from || leaf.__from).slice(0);
+
+  res.from = from.slice(0);
+  res.__filename = leaf.__filename;
+
   return res;
 }

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -4,7 +4,7 @@ var Promise = require('es6-promise').Promise; // jshint ignore:line
 var pluck = require('./pluck');
 var walk = require('./walk');
 var path = require('path');
-var depTypes = require('./consts');
+var depTypes = require('./dep-types');
 var colour = require('ansicolors');
 var _ = require('lodash');
 var format = require('util').format;
@@ -40,18 +40,20 @@ function logicalTree(fileTree, options) {
 
   var removedPaths = [];
 
-  // do a shallow pass on the deps and strip out dev deps
-  Object.keys(fileTree.dependencies).forEach(function (name) {
-    var dep = fileTree.dependencies[name];
-    // if we're not interested in devDeps, then strip them out
-    if (!options.dev && dep.depType === depTypes.DEV) {
-      // since dev deps are only ever on the root, we know we can remove it
-      // directly from the logicalRoot.dependencies
-      removedPaths.push(dep.__from);
-      delete logicalRoot.dependencies[dep.name];
-      return;
-    }
-  });
+  if (!options.dev) {
+    // do a shallow pass on the deps and strip out dev deps
+    Object.keys(fileTree.dependencies).forEach(function (name) {
+      var dep = fileTree.dependencies[name];
+      // if we're not interested in devDeps, then strip them out
+      if (dep.depType === depTypes.DEV) {
+        // since dev deps are only ever on the root, we know we can remove it
+        // directly from the logicalRoot.dependencies
+        removedPaths.push(dep.__from);
+        delete logicalRoot.dependencies[dep.name];
+        return;
+      }
+    });
+  }
 
   walk(fileTree.dependencies, function (dep) {
     if (!dep.__used) {
@@ -73,6 +75,10 @@ function logicalTree(fileTree, options) {
       leaf.extraneous = true;
       leaf.depType = depTypes.EXTRANEOUS;
       leaf.dependencies = walkDeps(fileTree, dep);
+      walk(leaf.dependencies, function (dep) {
+        dep.extraneous = true;
+        dep.depType = depTypes.EXTRANEOUS;
+      });
       insertLeaf(logicalRoot, leaf, dep.__from);
     }
   });
@@ -103,6 +109,8 @@ function walkDeps(root, tree, from) {
   var deps = _.extend({}, tree.__dependencies,
     tree.__from && from.length === 1 ? tree.__devDependencies : {});
 
+  deps = _.extend(deps, tree.__optionalDependencies);
+
   return Object.keys(deps).reduce(function walkDepsPicker(acc, curr) {
     // only attempt to walk this dep if it's not in our path already
     if (tree.__from.indexOf(curr) === -1) {
@@ -118,6 +126,14 @@ function walkDeps(root, tree, from) {
       if (from.indexOf(dep.name) === -1) {
         var pkg = acc[dep.name] = copy(dep, from.concat(dep.name));
         dep.__used = true;
+        var info = depTypes(dep.name, {
+          dependencies: tree.__dependencies,
+          devDependencies: tree.__devDependencies,
+          optionalDependencies: tree.__optionalDependencies,
+        });
+
+        pkg.depType = info.type;
+        pkg.dep = info.from;
         pkg.dependencies = walkDeps(root, dep, pkg.from);
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "lint": "jscs cli/*.js lib/*.js -v",
+    "check-tests": "! grep 'test.only' test/*.test.js -n",
     "env": "node -e 'console.log(process.env, process.versions)'",
     "cover": "tap test/*.test.js --cov --coverage-report=lcov",
-    "test": "npm run lint && tap test/*.test.js --cov --timeout=60",
+    "test": "npm run check-tests && npm run lint && tap test/*.test.js --cov --timeout=60",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "author": "Remy Sharp",
@@ -20,7 +21,7 @@
   "devDependencies": {
     "jscs": "^2.8.0",
     "semantic-release": "^4.3.5",
-    "snyk-resolve-deps-fixtures": "^1.1.2",
+    "snyk-resolve-deps-fixtures": "^1.1.3",
     "tap": "^5.1.1",
     "tap-only": "0.0.5",
     "tape": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.0.0",
     "lru-cache": "^4.0.0",
     "semver": "^5.1.0",
-    "snyk": "*",
     "snyk-module": "^1.0.2",
     "snyk-resolve": "^1.0.0",
     "then-fs": "^2.0.0"

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -43,7 +43,7 @@ test('end to end (this package with dev)', function (t) {
     t.ok(fixtures, 'has the fixtures dep');
     t.equal(fixtures.dependencies['@remy/npm-tree'].name, '@remy/npm-tree', 'has npm-tree');
     t.equal(fixtures.dependencies['@remy/vuln-test'].name, '@remy/vuln-test', 'has vuln-test');
-    t.equal(res.dependencies['snyk-resolve-deps-fixtures'].dependencies.undefsafe.extraneous, true, 'is extraneous');
+    t.equal(fixtures.dependencies.undefsafe.extraneous, true, 'is extraneous');
 
     var plucked = res.pluck(['snyk-resolve-deps@1', 'snyk-resolve-deps-fixtures@1', '@remy/npm-tree'], '@remy/npm-tree', '*');
     t.equal(plucked.name, '@remy/npm-tree');

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -1,5 +1,6 @@
 var test = require('tap-only');
 var resolveTree = require('../lib');
+var logicalTree = require('../lib/logical');
 var path = require('path');
 var walk = require('../lib/walk');
 var depTypes = require('../lib/consts');
@@ -10,6 +11,8 @@ var npm3fixture = path.resolve(__dirname, '..',
     'node_modules/snyk-resolve-deps-fixtures');
 var rootfixtures = path.resolve(__dirname, '..');
 var missingfixtures = path.resolve(__dirname, 'fixtures/pkg-missing-deps');
+var hawkpkg = require(path.resolve(__dirname, '..',
+    'node_modules/snyk-resolve-deps-fixtures/snyk-vuln-tree.json'));
 
 test('logical', function (t) {
   resolveTree(npm3fixture).then(function () {
@@ -23,10 +26,7 @@ test('logical (flags missing module)', function (t) {
       return issue.indexOf('missing') === 0;
     });
     t.ok(problem, 'The missing package was flagged');
-  }).catch(function (e) {
-    console.log(e.stack);
-    e.fail(e);
-  }).then(t.end);
+  }).catch(t.threw).then(t.end);
 });
 
 test('logical (find devDeps)', function (t) {
@@ -45,7 +45,7 @@ test('logical (find devDeps)', function (t) {
     }
 
     t.equal(names.length, expect, 'found the right number of devDeps');
-  }).catch(t.fail).then(t.end);
+  }).catch(t.threw).then(t.end);
 });
 
 test('logical (deep test, find scoped)', function (t) {
@@ -60,7 +60,7 @@ test('logical (deep test, find scoped)', function (t) {
         t.pass('found scopped dependency');
       }
     });
-  }).catch(t.fail);
+  }).catch(t.threw);
 });
 
 test('deps - with uglify-package', function (t) {
@@ -71,9 +71,7 @@ test('deps - with uglify-package', function (t) {
 
     var ugdeep = res.dependencies['ug-deep'];
     t.equal(ugdeep.name, 'ug-deep', 'ug-deep exists');
-  }).catch(function (e) {
-    t.fail(e.stack);
-  }).then(t.end);
+  }).catch(t.threw).then(t.end);
 
 });
 
@@ -95,7 +93,7 @@ test('logical (deep test, expecting extraneous)', function (t) {
     // package. undefsafe + debug are manually installed, but ms comes in via
     // debug, and because it's unknown to us, it's also extraneous.
     t.ok(count === 3 || count === 5, 'found ' + count + ' extraneous packages');
-  }).catch(t.fail).then(t.end);
+  }).catch(t.threw).then(t.end);
 });
 
 test('logical (find semver multiple times)', function (t) {
@@ -108,5 +106,22 @@ test('logical (find semver multiple times)', function (t) {
       return f === 'semver';
     }).length;
     t.equal(count, 2, 'expecting 2 semvers');
-  }).catch(t.fail).then(t.end);
+  }).catch(t.threw).then(t.end);
+});
+
+test('logical (deep copies)', function (t) {
+  var res = logicalTree(hawkpkg);
+  var deps = [];
+  var paths = {};
+  walk(res, function (dep) {
+    if (dep.name === 'hawk') {
+      deps.push(dep);
+      paths[dep.from] = 1;
+    }
+  });
+
+  t.equal(deps.length, 5, 'found 5 instance');
+  t.equal(Object.keys(paths).length, 5, 'in 5 different paths');
+
+  t.end();
 });

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -3,7 +3,7 @@ var resolveTree = require('../lib');
 var logicalTree = require('../lib/logical');
 var path = require('path');
 var walk = require('../lib/walk');
-var depTypes = require('../lib/consts');
+var depTypes = require('../lib/dep-types');
 var tree = require('@remy/npm-tree');
 var uglifyfixture = path.resolve(__dirname, '..',
     'node_modules/snyk-resolve-deps-fixtures/node_modules/uglify-package');
@@ -30,21 +30,19 @@ test('logical (flags missing module)', function (t) {
 });
 
 test('logical (find devDeps)', function (t) {
-  var expect = Object.keys(require('../package.json').devDependencies).length;
+  var devDeps = Object.keys(require('../package.json').devDependencies);
+  var expect = devDeps.length;
   resolveTree(rootfixtures, { dev: true }).then(function (res) {
     var names = [];
+    // console.log(res.dependencies['snyk-resolve-deps-fixtures'].dependencies['@remy/npm-tree']);
     walk(res, function (dep) {
       if (dep.depType === depTypes.DEV) {
         names.push(dep.name);
       }
     });
 
-    // I don't know right now, but this is a thing...FIXME
-    if (names.length === 8) {
-      expect = 8;
-    }
 
-    t.equal(names.length, expect, 'found the right number of devDeps');
+    t.deepEqual(names, devDeps, 'found the right number of devDeps');
   }).catch(t.threw).then(t.end);
 });
 

--- a/test/pluck.test.js
+++ b/test/pluck.test.js
@@ -37,7 +37,7 @@ function pluckTests(t, res) {
   plucked = pluck(res, ['snyk-resolve-deps','snyk','inquirer', 'lodash'], name, '*');
   t.equal(plucked.name, name, 'found in deduped path');
 
-  plucked = pluck(res, ['__noop__','inquirer'], name, '*');
+  plucked = pluck(res, ['this-module-does-not-exist','inquirer'], name, '*');
   t.equal(plucked, false, 'should not find a package with invalid path');
 
   plucked = pluck(res, ['snyk-resolve-deps'], name, '*');


### PR DESCRIPTION
- [x] Reviewed by @maban
#### What's this PR do?

Fully resolves the logical tree when there's deduped packages.
#### Where should the reviewer start?

See comments in diff.
#### How should this be manually tested?

Clone locally, run `npm link`, then run `snyk-resolve -c hawk` in the vuln#develop branch. It should return five unique instances of hawk. Where as right now it does this:
#### Any background context you want to provide?

Found that the dependencies were being copied as a reference when the `copy` function was being called (and then overwritten), which results is a logical tree closer to what the `npm ls` output looks like.

This fix skips over the dependencies in the copy process and then rebuilds the deps. The important change is that the `from` property is correctly tracked when we're copying a full partial tree across from one package to another. The code also prevents circular (infinite) depth by tracking the heritage (the `from`) and if the package already appears in the path, it won't try to resolve the deps (again).

This can seen when you install the es6-map package as it has a large circular tree.
#### What are the relevant tickets?

Ref SC-777
#### Screenshots

May or may not make you do this:

![break-dancing-hamster-o](https://cloud.githubusercontent.com/assets/13700/12847513/be2ce5b6-cc0b-11e5-9eaa-2ebf3b225f1c.gif)
