### PR TITLE
fix: local pluck for deduped package

### DIFF
--- a/lib/pluck.js
+++ b/lib/pluck.js
@@ -38,7 +38,7 @@ function pluck(root, path, name, range) {
   // walk the depth of `from` to find the `dependencies` property from `root`
   // if it can't be found, pop `from` and try again until `from` is empty
   do {
-    var pkg = findPackage(root, from, name, range);
+    var pkg = findPackage(root, from.slice(0), name, range);
 
     if (pkg) {
       return pkg;

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -11,6 +11,23 @@ test('end to end (no deps)', function (t) {
   .then(t.end);
 });
 
+test('end to end (sub-pluck finds correctly)', function (t) {
+  var res = lib.logicalTree(require(__dirname + '/fixtures/oui.json'));
+  var from = [ 'foo@1.0.0',
+    'chokidar@1.4.1',
+    'fsevents@1.0.7',
+    'node-pre-gyp@0.6.19',
+    'request@2.67.0',
+    'hawk@3.1.2' ];
+
+  var plucked = res.pluck(from, 'hawk', '3.1.2');
+
+  t.notEqual(plucked, false, 'managed to pluck');
+  t.equal(plucked.name, 'hawk', 'found hawk');
+  t.end();
+});
+
+
 test('end to end (no name on root pkg)', function (t) {
   lib(__dirname + '/fixtures/pkg-missing-name')
   .then(function (res) {

--- a/test/fixtures/oui.json
+++ b/test/fixtures/oui.json
@@ -1,0 +1,5022 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "license": "ISC",
+  "depType": {
+    "_": [
+      "/Users/remy/.nvm/versions/node/v4.2.4/bin/node",
+      "/Users/remy/.nvm/versions/node/v4.2.4/bin/snyk-resolve"
+    ],
+    "help": false,
+    "disk": true,
+    "json": true,
+    "errors": false,
+    "dev": false,
+    "production": false,
+    "optional": false,
+    "bundled": false,
+    "extraneous": false,
+    "e": false
+  },
+  "hasDevDependencies": true,
+  "full": "foo@1.0.0",
+  "__from": [
+    "foo"
+  ],
+  "__devDependencies": {},
+  "__dependencies": {
+    "chokidar": "^1.4.1"
+  },
+  "__filename": "/Users/remy/Sites/snyk-tests/foo/package.json",
+  "dependencies": {
+    "chokidar": {
+      "name": "chokidar",
+      "version": "1.4.1",
+      "full": "chokidar@1.4.1",
+      "valid": true,
+      "depType": "prod",
+      "snyk": false,
+      "license": "MIT",
+      "dep": "^1.4.1",
+      "bundled": false,
+      "__from": [
+        "foo",
+        "chokidar"
+      ],
+      "__devDependencies": {
+        "chai": "^3.2.0",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.20",
+        "mocha": "^2.0.0",
+        "rimraf": "^2.4.3",
+        "sinon": "^1.10.3",
+        "sinon-chai": "^2.6.0"
+      },
+      "__dependencies": {
+        "anymatch": "^1.3.0",
+        "async-each": "^0.1.6",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "fsevents": "^1.0.0"
+      },
+      "__optionalDependencies": {
+        "fsevents": "^1.0.0"
+      },
+      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/package.json",
+      "dependencies": {
+        "anymatch": {
+          "name": "anymatch",
+          "version": "1.3.0",
+          "full": "anymatch@1.3.0",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "ISC",
+          "dep": "^1.3.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "anymatch"
+          ],
+          "__devDependencies": {
+            "coveralls": "^2.11.2",
+            "istanbul": "^0.3.13",
+            "mocha": "^2.2.4"
+          },
+          "__dependencies": {
+            "arrify": "^1.0.0",
+            "micromatch": "^2.1.5"
+          },
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/package.json",
+          "dependencies": {
+            "arrify": {
+              "name": "arrify",
+              "version": "1.0.1",
+              "full": "arrify@1.0.1",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^1.0.0",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "anymatch",
+                "arrify"
+              ],
+              "__devDependencies": {
+                "ava": "*",
+                "xo": "*"
+              },
+              "__dependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/arrify/package.json",
+              "dependencies": {}
+            },
+            "micromatch": {
+              "name": "micromatch",
+              "version": "2.3.7",
+              "full": "micromatch@2.3.7",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^2.1.5",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "anymatch",
+                "micromatch"
+              ],
+              "__devDependencies": {
+                "benchmarked": "^0.1.4",
+                "chalk": "^1.1.1",
+                "gulp": "^3.9.0",
+                "gulp-eslint": "^1.1.1",
+                "gulp-istanbul": "^0.10.1",
+                "gulp-mocha": "^2.1.3",
+                "minimatch": "^3.0.0",
+                "minimist": "^1.2.0",
+                "mocha": "*",
+                "multimatch": "^2.0.0",
+                "should": "*",
+                "write": "^0.2.1"
+              },
+              "__dependencies": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              },
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/package.json",
+              "dependencies": {
+                "arr-diff": {
+                  "name": "arr-diff",
+                  "version": "2.0.0",
+                  "full": "arr-diff@2.0.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^2.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "arr-diff"
+                  ],
+                  "__devDependencies": {
+                    "array-differ": "^1.0.0",
+                    "array-slice": "^0.2.3",
+                    "benchmarked": "^0.1.4",
+                    "chalk": "^1.1.1",
+                    "mocha": "*",
+                    "should": "*"
+                  },
+                  "__dependencies": {
+                    "arr-flatten": "^1.0.1"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/arr-diff/package.json",
+                  "dependencies": {
+                    "arr-flatten": {
+                      "name": "arr-flatten",
+                      "version": "1.0.1",
+                      "full": "arr-flatten@1.0.1",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.0.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "arr-diff",
+                        "arr-flatten"
+                      ],
+                      "__devDependencies": {
+                        "array-flatten": "^1.0.2",
+                        "array-slice": "^0.2.2",
+                        "benchmarked": "^0.1.3",
+                        "chalk": "^0.5.1",
+                        "glob": "^4.3.5",
+                        "kind-of": "^1.0.0"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/arr-diff/node_modules/arr-flatten/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                },
+                "array-unique": {
+                  "name": "array-unique",
+                  "version": "0.2.1",
+                  "full": "array-unique@0.2.1",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^0.2.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "array-unique"
+                  ],
+                  "__devDependencies": {
+                    "array-uniq": "^1.0.2",
+                    "benchmarked": "^0.1.3",
+                    "mocha": "*",
+                    "should": "*"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/array-unique/package.json",
+                  "dependencies": {}
+                },
+                "braces": {
+                  "name": "braces",
+                  "version": "1.8.3",
+                  "full": "braces@1.8.3",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^1.8.2",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "braces"
+                  ],
+                  "__devDependencies": {
+                    "benchmarked": "^0.1.3",
+                    "brace-expansion": "^1.1.0",
+                    "chalk": "^0.5.1",
+                    "minimatch": "^2.0.1",
+                    "minimist": "^1.1.0",
+                    "mocha": "*",
+                    "should": "*"
+                  },
+                  "__dependencies": {
+                    "expand-range": "^1.8.1",
+                    "preserve": "^0.2.0",
+                    "repeat-element": "^1.1.2"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/package.json",
+                  "dependencies": {
+                    "expand-range": {
+                      "name": "expand-range",
+                      "version": "1.8.1",
+                      "full": "expand-range@1.8.1",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.8.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "braces",
+                        "expand-range"
+                      ],
+                      "__devDependencies": {
+                        "benchmarked": "^0.1.1",
+                        "brace-expansion": "^1.1.0",
+                        "glob": "^4.3.2",
+                        "minimatch": "^2.0.1",
+                        "mocha": "*",
+                        "should": "^4.1.0"
+                      },
+                      "__dependencies": {
+                        "fill-range": "^2.1.0"
+                      },
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/package.json",
+                      "dependencies": {
+                        "fill-range": {
+                          "name": "fill-range",
+                          "version": "2.2.3",
+                          "full": "fill-range@2.2.3",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "^2.1.0",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "anymatch",
+                            "micromatch",
+                            "braces",
+                            "expand-range",
+                            "fill-range"
+                          ],
+                          "__devDependencies": {
+                            "benchmarked": "^0.1.3",
+                            "chalk": "^0.5.1",
+                            "should": "*"
+                          },
+                          "__dependencies": {
+                            "is-number": "^2.1.0",
+                            "isobject": "^2.0.0",
+                            "randomatic": "^1.1.3",
+                            "repeat-element": "^1.1.2",
+                            "repeat-string": "^1.5.2"
+                          },
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/package.json",
+                          "dependencies": {
+                            "is-number": {
+                              "name": "is-number",
+                              "version": "2.1.0",
+                              "full": "is-number@2.1.0",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^2.1.0",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "anymatch",
+                                "micromatch",
+                                "braces",
+                                "expand-range",
+                                "fill-range",
+                                "is-number"
+                              ],
+                              "__devDependencies": {
+                                "benchmarked": "^0.1.3",
+                                "chalk": "^0.5.1",
+                                "mocha": "*"
+                              },
+                              "__dependencies": {
+                                "kind-of": "^3.0.2"
+                              },
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/node_modules/is-number/package.json",
+                              "dependencies": {}
+                            },
+                            "isobject": {
+                              "name": "isobject",
+                              "version": "2.0.0",
+                              "full": "isobject@2.0.0",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^2.0.0",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "anymatch",
+                                "micromatch",
+                                "braces",
+                                "expand-range",
+                                "fill-range",
+                                "isobject"
+                              ],
+                              "__devDependencies": {
+                                "mocha": "*"
+                              },
+                              "__dependencies": {
+                                "isarray": "0.0.1"
+                              },
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/node_modules/isobject/package.json",
+                              "dependencies": {
+                                "isarray": {
+                                  "name": "isarray",
+                                  "version": "0.0.1",
+                                  "full": "isarray@0.0.1",
+                                  "valid": true,
+                                  "depType": "prod",
+                                  "snyk": false,
+                                  "license": "MIT",
+                                  "dep": "0.0.1",
+                                  "bundled": false,
+                                  "__from": [
+                                    "foo",
+                                    "chokidar",
+                                    "anymatch",
+                                    "micromatch",
+                                    "braces",
+                                    "expand-range",
+                                    "fill-range",
+                                    "isobject",
+                                    "isarray"
+                                  ],
+                                  "__devDependencies": {
+                                    "tap": "*"
+                                  },
+                                  "__dependencies": {},
+                                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/node_modules/isobject/node_modules/isarray/package.json",
+                                  "dependencies": {}
+                                }
+                              }
+                            },
+                            "randomatic": {
+                              "name": "randomatic",
+                              "version": "1.1.5",
+                              "full": "randomatic@1.1.5",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^1.1.3",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "anymatch",
+                                "micromatch",
+                                "braces",
+                                "expand-range",
+                                "fill-range",
+                                "randomatic"
+                              ],
+                              "__devDependencies": {
+                                "ansi-bold": "^0.1.1",
+                                "benchmarked": "^0.1.4",
+                                "glob": "^5.0.15",
+                                "mocha": "*",
+                                "should": "*"
+                              },
+                              "__dependencies": {
+                                "is-number": "^2.0.2",
+                                "kind-of": "^3.0.2"
+                              },
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/node_modules/randomatic/package.json",
+                              "dependencies": {}
+                            },
+                            "repeat-string": {
+                              "name": "repeat-string",
+                              "version": "1.5.2",
+                              "full": "repeat-string@1.5.2",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^1.5.2",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "anymatch",
+                                "micromatch",
+                                "braces",
+                                "expand-range",
+                                "fill-range",
+                                "repeat-string"
+                              ],
+                              "__devDependencies": {
+                                "benchmarked": "^0.1.3",
+                                "chalk": "^0.5.1",
+                                "glob": "^4.3.5",
+                                "mocha": "^2.2.1",
+                                "repeating": "^1.1.1",
+                                "should": "^4.0.4"
+                              },
+                              "__dependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/expand-range/node_modules/fill-range/node_modules/repeat-string/package.json",
+                              "dependencies": {}
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "preserve": {
+                      "name": "preserve",
+                      "version": "0.2.0",
+                      "full": "preserve@0.2.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.2.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "braces",
+                        "preserve"
+                      ],
+                      "__devDependencies": {
+                        "benchmarked": "^0.1.3",
+                        "chalk": "^0.5.1",
+                        "js-beautify": "^1.5.4",
+                        "mocha": "*",
+                        "should": "*"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/preserve/package.json",
+                      "dependencies": {}
+                    },
+                    "repeat-element": {
+                      "name": "repeat-element",
+                      "version": "1.1.2",
+                      "full": "repeat-element@1.1.2",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.1.2",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "braces",
+                        "repeat-element"
+                      ],
+                      "__devDependencies": {
+                        "benchmarked": "^0.1.4",
+                        "chalk": "^1.0.0",
+                        "glob": "^5.0.5",
+                        "minimist": "^1.1.1",
+                        "mocha": "^2.2.4"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/braces/node_modules/repeat-element/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "name": "expand-brackets",
+                  "version": "0.1.4",
+                  "full": "expand-brackets@0.1.4",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^0.1.4",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "expand-brackets"
+                  ],
+                  "__devDependencies": {
+                    "mocha": "^2.2.5",
+                    "should": "^7.0.2"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/expand-brackets/package.json",
+                  "dependencies": {}
+                },
+                "extglob": {
+                  "name": "extglob",
+                  "version": "0.3.2",
+                  "full": "extglob@0.3.2",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^0.3.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "extglob"
+                  ],
+                  "__devDependencies": {
+                    "ansi-green": "^0.1.1",
+                    "micromatch": "^2.1.6",
+                    "minimatch": "^2.0.1",
+                    "minimist": "^1.1.0",
+                    "mocha": "*",
+                    "should": "*",
+                    "success-symbol": "^0.1.0"
+                  },
+                  "__dependencies": {
+                    "is-extglob": "^1.0.0"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/extglob/package.json",
+                  "dependencies": {}
+                },
+                "filename-regex": {
+                  "name": "filename-regex",
+                  "version": "2.0.0",
+                  "full": "filename-regex@2.0.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^2.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "filename-regex"
+                  ],
+                  "__devDependencies": {},
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/filename-regex/package.json",
+                  "dependencies": {}
+                },
+                "is-extglob": {
+                  "name": "is-extglob",
+                  "version": "1.0.0",
+                  "full": "is-extglob@1.0.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^1.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "is-extglob"
+                  ],
+                  "__devDependencies": {
+                    "mocha": "*",
+                    "should": "*"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/is-extglob/package.json",
+                  "dependencies": {}
+                },
+                "kind-of": {
+                  "name": "kind-of",
+                  "version": "3.0.2",
+                  "full": "kind-of@3.0.2",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^3.0.2",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "kind-of"
+                  ],
+                  "__devDependencies": {
+                    "ansi-bold": "^0.1.1",
+                    "benchmarked": "^0.1.3",
+                    "browserify": "^11.0.1",
+                    "glob": "^4.3.5",
+                    "mocha": "*",
+                    "should": "*",
+                    "type-of": "^2.0.1",
+                    "typeof": "^1.0.0"
+                  },
+                  "__dependencies": {
+                    "is-buffer": "^1.0.2"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/kind-of/package.json",
+                  "dependencies": {
+                    "is-buffer": {
+                      "name": "is-buffer",
+                      "version": "1.1.2",
+                      "full": "is-buffer@1.1.2",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.0.2",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "kind-of",
+                        "is-buffer"
+                      ],
+                      "__devDependencies": {
+                        "standard": "^5.4.1",
+                        "tape": "^4.0.0",
+                        "zuul": "^3.0.0"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/kind-of/node_modules/is-buffer/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                },
+                "normalize-path": {
+                  "name": "normalize-path",
+                  "version": "2.0.1",
+                  "full": "normalize-path@2.0.1",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^2.0.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "normalize-path"
+                  ],
+                  "__devDependencies": {
+                    "benchmarked": "^0.1.1",
+                    "minimist": "^1.2.0",
+                    "mocha": "*"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/normalize-path/package.json",
+                  "dependencies": {}
+                },
+                "object.omit": {
+                  "name": "object.omit",
+                  "version": "2.0.0",
+                  "full": "object.omit@2.0.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^2.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "object.omit"
+                  ],
+                  "__devDependencies": {
+                    "mocha": "*",
+                    "should": "*"
+                  },
+                  "__dependencies": {
+                    "for-own": "^0.1.3",
+                    "is-extendable": "^0.1.1"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/object.omit/package.json",
+                  "dependencies": {
+                    "for-own": {
+                      "name": "for-own",
+                      "version": "0.1.3",
+                      "full": "for-own@0.1.3",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.1.3",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "object.omit",
+                        "for-own"
+                      ],
+                      "__devDependencies": {
+                        "mocha": "*",
+                        "should": "^5.2.0"
+                      },
+                      "__dependencies": {
+                        "for-in": "^0.1.4"
+                      },
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/object.omit/node_modules/for-own/package.json",
+                      "dependencies": {
+                        "for-in": {
+                          "name": "for-in",
+                          "version": "0.1.4",
+                          "full": "for-in@0.1.4",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "^0.1.4",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "anymatch",
+                            "micromatch",
+                            "object.omit",
+                            "for-own",
+                            "for-in"
+                          ],
+                          "__devDependencies": {
+                            "mocha": "*",
+                            "should": "^4.0.4"
+                          },
+                          "__dependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/object.omit/node_modules/for-own/node_modules/for-in/package.json",
+                          "dependencies": {}
+                        }
+                      }
+                    },
+                    "is-extendable": {
+                      "name": "is-extendable",
+                      "version": "0.1.1",
+                      "full": "is-extendable@0.1.1",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.1.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "object.omit",
+                        "is-extendable"
+                      ],
+                      "__devDependencies": {
+                        "mocha": "*"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/object.omit/node_modules/is-extendable/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                },
+                "parse-glob": {
+                  "name": "parse-glob",
+                  "version": "3.0.4",
+                  "full": "parse-glob@3.0.4",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^3.0.4",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "parse-glob"
+                  ],
+                  "__devDependencies": {
+                    "browserify": "^9.0.3",
+                    "lodash": "^3.3.1",
+                    "mocha": "*"
+                  },
+                  "__dependencies": {
+                    "glob-base": "^0.3.0",
+                    "is-dotfile": "^1.0.0",
+                    "is-extglob": "^1.0.0",
+                    "is-glob": "^2.0.0"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/parse-glob/package.json",
+                  "dependencies": {
+                    "glob-base": {
+                      "name": "glob-base",
+                      "version": "0.3.0",
+                      "full": "glob-base@0.3.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.3.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "parse-glob",
+                        "glob-base"
+                      ],
+                      "__devDependencies": {
+                        "mocha": "*",
+                        "should": "^5.1.0"
+                      },
+                      "__dependencies": {
+                        "glob-parent": "^2.0.0",
+                        "is-glob": "^2.0.0"
+                      },
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/parse-glob/node_modules/glob-base/package.json",
+                      "dependencies": {}
+                    },
+                    "is-dotfile": {
+                      "name": "is-dotfile",
+                      "version": "1.0.2",
+                      "full": "is-dotfile@1.0.2",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.0.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "parse-glob",
+                        "is-dotfile"
+                      ],
+                      "__devDependencies": {
+                        "benchmarked": "^0.1.3",
+                        "dotfile-regex": "^0.1.2",
+                        "mocha": "*"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/parse-glob/node_modules/is-dotfile/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "name": "regex-cache",
+                  "version": "0.4.2",
+                  "full": "regex-cache@0.4.2",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^0.4.2",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "anymatch",
+                    "micromatch",
+                    "regex-cache"
+                  ],
+                  "__devDependencies": {
+                    "benchmarked": "^0.1.4",
+                    "chalk": "^1.0.0",
+                    "micromatch": "^2.1.0",
+                    "mocha": "^2.1.0",
+                    "should": "*"
+                  },
+                  "__dependencies": {
+                    "is-equal-shallow": "^0.1.1",
+                    "is-primitive": "^2.0.0"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/regex-cache/package.json",
+                  "dependencies": {
+                    "is-equal-shallow": {
+                      "name": "is-equal-shallow",
+                      "version": "0.1.3",
+                      "full": "is-equal-shallow@0.1.3",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.1.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "regex-cache",
+                        "is-equal-shallow"
+                      ],
+                      "__devDependencies": {
+                        "mocha": "*",
+                        "should": "*"
+                      },
+                      "__dependencies": {
+                        "is-primitive": "^2.0.0"
+                      },
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/regex-cache/node_modules/is-equal-shallow/package.json",
+                      "dependencies": {}
+                    },
+                    "is-primitive": {
+                      "name": "is-primitive",
+                      "version": "2.0.0",
+                      "full": "is-primitive@2.0.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^2.0.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "anymatch",
+                        "micromatch",
+                        "regex-cache",
+                        "is-primitive"
+                      ],
+                      "__devDependencies": {
+                        "mocha": "*",
+                        "should": "^4.0.4"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/anymatch/node_modules/micromatch/node_modules/regex-cache/node_modules/is-primitive/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "async-each": {
+          "name": "async-each",
+          "version": "0.1.6",
+          "full": "async-each@0.1.6",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^0.1.6",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "async-each"
+          ],
+          "__devDependencies": {},
+          "__dependencies": {},
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/async-each/package.json",
+          "dependencies": {}
+        },
+        "fsevents": {
+          "name": "fsevents",
+          "version": "1.0.7",
+          "full": "fsevents@1.0.7",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^1.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "fsevents"
+          ],
+          "__devDependencies": {
+            "tap": "~0.4.8"
+          },
+          "__dependencies": {
+            "nan": "^2.1.0",
+            "node-pre-gyp": "^0.6.19"
+          },
+          "__bundleDependencies": [
+            "node-pre-gyp"
+          ],
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/package.json",
+          "dependencies": {
+            "ansi": {
+              "name": "ansi",
+              "version": "0.3.0",
+              "full": "ansi@0.3.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "none",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "ansi"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/ansi/package.json",
+              "dependencies": {}
+            },
+            "ansi-regex": {
+              "name": "ansi-regex",
+              "version": "2.0.0",
+              "full": "ansi-regex@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "ansi-regex"
+              ],
+              "__devDependencies": {
+                "mocha": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/ansi-regex/package.json",
+              "dependencies": {}
+            },
+            "ansi-styles": {
+              "name": "ansi-styles",
+              "version": "2.1.0",
+              "full": "ansi-styles@2.1.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "ansi-styles"
+              ],
+              "__devDependencies": {
+                "mocha": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/ansi-styles/package.json",
+              "dependencies": {}
+            },
+            "are-we-there-yet": {
+              "name": "are-we-there-yet",
+              "version": "1.0.5",
+              "full": "are-we-there-yet@1.0.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "are-we-there-yet"
+              ],
+              "__devDependencies": {
+                "tap": "^0.4.13"
+              },
+              "__dependencies": {
+                "delegates": "^0.1.0",
+                "readable-stream": "^2.0.0 || ^1.1.13"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/are-we-there-yet/package.json",
+              "dependencies": {}
+            },
+            "asn1": {
+              "name": "asn1",
+              "version": "0.2.3",
+              "full": "asn1@0.2.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "asn1"
+              ],
+              "__devDependencies": {
+                "tap": "0.4.8"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/asn1/package.json",
+              "dependencies": {}
+            },
+            "assert-plus": {
+              "name": "assert-plus",
+              "version": "0.1.5",
+              "full": "assert-plus@0.1.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "none",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "assert-plus"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/assert-plus/package.json",
+              "dependencies": {}
+            },
+            "async": {
+              "name": "async",
+              "version": "1.5.1",
+              "full": "async@1.5.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "async"
+              ],
+              "__devDependencies": {
+                "benchmark": "github:bestiejs/benchmark.js",
+                "bluebird": "^2.9.32",
+                "chai": "^3.1.0",
+                "coveralls": "^2.11.2",
+                "es6-promise": "^2.3.0",
+                "jscs": "^1.13.1",
+                "jshint": "~2.8.0",
+                "karma": "^0.13.2",
+                "karma-browserify": "^4.2.1",
+                "karma-firefox-launcher": "^0.1.6",
+                "karma-mocha": "^0.2.0",
+                "karma-mocha-reporter": "^1.0.2",
+                "lodash": "^3.9.0",
+                "mkdirp": "~0.5.1",
+                "mocha": "^2.2.5",
+                "native-promise-only": "^0.8.0-a",
+                "nodeunit": ">0.0.0",
+                "nyc": "^2.1.0",
+                "rsvp": "^3.0.18",
+                "semver": "^4.3.6",
+                "uglify-js": "~2.4.0",
+                "xyz": "^0.5.0",
+                "yargs": "~3.9.1"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/async/package.json",
+              "dependencies": {}
+            },
+            "aws-sign2": {
+              "name": "aws-sign2",
+              "version": "0.6.0",
+              "full": "aws-sign2@0.6.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "aws-sign2"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/aws-sign2/package.json",
+              "dependencies": {}
+            },
+            "bl": {
+              "name": "bl",
+              "version": "1.0.0",
+              "full": "bl@1.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "bl"
+              ],
+              "__devDependencies": {
+                "brtapsauce": "~0.3.0",
+                "faucet": "~0.0.1",
+                "hash_file": "~0.1.1",
+                "tape": "~2.12.3"
+              },
+              "__dependencies": {
+                "readable-stream": "~2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/bl/package.json",
+              "dependencies": {}
+            },
+            "block-stream": {
+              "name": "block-stream",
+              "version": "0.0.8",
+              "full": "block-stream@0.0.8",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "block-stream"
+              ],
+              "__devDependencies": {
+                "tap": "0.x"
+              },
+              "__dependencies": {
+                "inherits": "~2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/block-stream/package.json",
+              "dependencies": {}
+            },
+            "boom": {
+              "name": "boom",
+              "version": "2.10.1",
+              "full": "boom@2.10.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "boom"
+              ],
+              "__devDependencies": {
+                "code": "1.x.x",
+                "lab": "7.x.x"
+              },
+              "__dependencies": {
+                "hoek": "2.x.x"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/boom/package.json",
+              "dependencies": {}
+            },
+            "caseless": {
+              "name": "caseless",
+              "version": "0.11.0",
+              "full": "caseless@0.11.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "caseless"
+              ],
+              "__devDependencies": {
+                "tape": "^2.10.2"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/caseless/package.json",
+              "dependencies": {}
+            },
+            "chalk": {
+              "name": "chalk",
+              "version": "1.1.1",
+              "full": "chalk@1.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "chalk"
+              ],
+              "__devDependencies": {
+                "coveralls": "^2.11.2",
+                "matcha": "^0.6.0",
+                "mocha": "*",
+                "nyc": "^3.0.0",
+                "require-uncached": "^1.0.2",
+                "resolve-from": "^1.0.0",
+                "semver": "^4.3.3",
+                "xo": "*"
+              },
+              "__dependencies": {
+                "ansi-styles": "^2.1.0",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/chalk/package.json",
+              "dependencies": {}
+            },
+            "combined-stream": {
+              "name": "combined-stream",
+              "version": "1.0.5",
+              "full": "combined-stream@1.0.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "combined-stream"
+              ],
+              "__devDependencies": {
+                "far": "~0.0.7"
+              },
+              "__dependencies": {
+                "delayed-stream": "~1.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/combined-stream/package.json",
+              "dependencies": {}
+            },
+            "commander": {
+              "name": "commander",
+              "version": "2.9.0",
+              "full": "commander@2.9.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "commander"
+              ],
+              "__devDependencies": {
+                "should": ">= 0.0.1",
+                "sinon": ">=1.17.1"
+              },
+              "__dependencies": {
+                "graceful-readlink": ">= 1.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/commander/package.json",
+              "dependencies": {}
+            },
+            "core-util-is": {
+              "name": "core-util-is",
+              "version": "1.0.2",
+              "full": "core-util-is@1.0.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "core-util-is"
+              ],
+              "__devDependencies": {
+                "tap": "^2.3.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/core-util-is/package.json",
+              "dependencies": {}
+            },
+            "cryptiles": {
+              "name": "cryptiles",
+              "version": "2.0.5",
+              "full": "cryptiles@2.0.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "cryptiles"
+              ],
+              "__devDependencies": {
+                "code": "1.x.x",
+                "lab": "5.x.x"
+              },
+              "__dependencies": {
+                "boom": "2.x.x"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/cryptiles/package.json",
+              "dependencies": {}
+            },
+            "dashdash": {
+              "name": "dashdash",
+              "version": "1.11.0",
+              "full": "dashdash@1.11.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "dashdash"
+              ],
+              "__devDependencies": {
+                "nodeunit": "0.9.x"
+              },
+              "__dependencies": {
+                "assert-plus": "0.1.x"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/dashdash/package.json",
+              "dependencies": {}
+            },
+            "debug": {
+              "name": "debug",
+              "version": "0.7.4",
+              "full": "debug@0.7.4",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "none",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "debug"
+              ],
+              "__devDependencies": {
+                "mocha": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/debug/package.json",
+              "dependencies": {}
+            },
+            "deep-extend": {
+              "name": "deep-extend",
+              "version": "0.4.0",
+              "full": "deep-extend@0.4.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "deep-extend"
+              ],
+              "__devDependencies": {
+                "mocha": "^2.2.1",
+                "should": "^5.2.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/deep-extend/package.json",
+              "dependencies": {}
+            },
+            "delayed-stream": {
+              "name": "delayed-stream",
+              "version": "1.0.0",
+              "full": "delayed-stream@1.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "delayed-stream"
+              ],
+              "__devDependencies": {
+                "fake": "0.2.0",
+                "far": "0.0.1"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/delayed-stream/package.json",
+              "dependencies": {}
+            },
+            "delegates": {
+              "name": "delegates",
+              "version": "0.1.0",
+              "full": "delegates@0.1.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "delegates"
+              ],
+              "__devDependencies": {
+                "mocha": "*",
+                "should": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/delegates/package.json",
+              "dependencies": {}
+            },
+            "ecc-jsbn": {
+              "name": "ecc-jsbn",
+              "version": "0.1.1",
+              "full": "ecc-jsbn@0.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "ecc-jsbn"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "jsbn": "~0.1.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/ecc-jsbn/package.json",
+              "dependencies": {}
+            },
+            "escape-string-regexp": {
+              "name": "escape-string-regexp",
+              "version": "1.0.4",
+              "full": "escape-string-regexp@1.0.4",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "escape-string-regexp"
+              ],
+              "__devDependencies": {
+                "ava": "*",
+                "xo": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/escape-string-regexp/package.json",
+              "dependencies": {}
+            },
+            "extend": {
+              "name": "extend",
+              "version": "3.0.0",
+              "full": "extend@3.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "extend"
+              ],
+              "__devDependencies": {
+                "covert": "^1.1.0",
+                "eslint": "^0.24.0",
+                "jscs": "^1.13.1",
+                "tape": "^4.0.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/extend/package.json",
+              "dependencies": {}
+            },
+            "extsprintf": {
+              "name": "extsprintf",
+              "version": "1.0.2",
+              "full": "extsprintf@1.0.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "none",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "extsprintf"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/extsprintf/package.json",
+              "dependencies": {}
+            },
+            "forever-agent": {
+              "name": "forever-agent",
+              "version": "0.6.1",
+              "full": "forever-agent@0.6.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "forever-agent"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/forever-agent/package.json",
+              "dependencies": {}
+            },
+            "form-data": {
+              "name": "form-data",
+              "version": "1.0.0-rc3",
+              "full": "form-data@1.0.0-rc3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "form-data"
+              ],
+              "__devDependencies": {
+                "fake": "^0.2.2",
+                "far": "^0.0.7",
+                "formidable": "^1.0.17",
+                "pre-commit": "^1.0.10",
+                "request": "^2.60.0"
+              },
+              "__dependencies": {
+                "async": "^1.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.3"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/form-data/package.json",
+              "dependencies": {}
+            },
+            "fstream": {
+              "name": "fstream",
+              "version": "1.0.8",
+              "full": "fstream@1.0.8",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "fstream"
+              ],
+              "__devDependencies": {
+                "standard": "^4.0.0",
+                "tap": "^1.2.0"
+              },
+              "__dependencies": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream/package.json",
+              "dependencies": {}
+            },
+            "fstream-ignore": {
+              "name": "fstream-ignore",
+              "version": "1.0.3",
+              "full": "fstream-ignore@1.0.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "fstream-ignore"
+              ],
+              "__devDependencies": {
+                "mkdirp": "",
+                "rimraf": "",
+                "tap": "^2.2.0"
+              },
+              "__dependencies": {
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream-ignore/package.json",
+              "dependencies": {
+                "minimatch": {
+                  "name": "minimatch",
+                  "version": "3.0.0",
+                  "full": "minimatch@3.0.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "ISC",
+                  "dep": "^3.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "fstream-ignore",
+                    "minimatch"
+                  ],
+                  "__devDependencies": {
+                    "standard": "^3.7.2",
+                    "tap": "^1.2.0"
+                  },
+                  "__dependencies": {
+                    "brace-expansion": "^1.0.0"
+                  },
+                  "__optionalDependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream-ignore/node_modules/minimatch/package.json",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "name": "brace-expansion",
+                      "version": "1.1.2",
+                      "full": "brace-expansion@1.1.2",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.0.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "fstream-ignore",
+                        "minimatch",
+                        "brace-expansion"
+                      ],
+                      "__devDependencies": {
+                        "tape": "4.2.2"
+                      },
+                      "__dependencies": {
+                        "balanced-match": "^0.3.0",
+                        "concat-map": "0.0.1"
+                      },
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/package.json",
+                      "dependencies": {
+                        "balanced-match": {
+                          "name": "balanced-match",
+                          "version": "0.3.0",
+                          "full": "balanced-match@0.3.0",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "^0.3.0",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "fstream-ignore",
+                            "minimatch",
+                            "brace-expansion",
+                            "balanced-match"
+                          ],
+                          "__devDependencies": {
+                            "tape": "~4.2.2"
+                          },
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match/package.json",
+                          "dependencies": {}
+                        },
+                        "concat-map": {
+                          "name": "concat-map",
+                          "version": "0.0.1",
+                          "full": "concat-map@0.0.1",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "0.0.1",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "fstream-ignore",
+                            "minimatch",
+                            "brace-expansion",
+                            "concat-map"
+                          ],
+                          "__devDependencies": {
+                            "tape": "~2.4.0"
+                          },
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/fstream-ignore/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map/package.json",
+                          "dependencies": {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "gauge": {
+              "name": "gauge",
+              "version": "1.2.2",
+              "full": "gauge@1.2.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "gauge"
+              ],
+              "__devDependencies": {
+                "tap": "^0.4.13"
+              },
+              "__dependencies": {
+                "ansi": "^0.3.0",
+                "has-unicode": "^1.0.0",
+                "lodash.pad": "^3.0.0",
+                "lodash.padleft": "^3.0.0",
+                "lodash.padright": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/gauge/package.json",
+              "dependencies": {}
+            },
+            "generate-function": {
+              "name": "generate-function",
+              "version": "2.0.0",
+              "full": "generate-function@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "generate-function"
+              ],
+              "__devDependencies": {
+                "tape": "^2.13.4"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/generate-function/package.json",
+              "dependencies": {}
+            },
+            "generate-object-property": {
+              "name": "generate-object-property",
+              "version": "1.2.0",
+              "full": "generate-object-property@1.2.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "generate-object-property"
+              ],
+              "__devDependencies": {
+                "tape": "^2.13.0"
+              },
+              "__dependencies": {
+                "is-property": "^1.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/generate-object-property/package.json",
+              "dependencies": {}
+            },
+            "graceful-fs": {
+              "name": "graceful-fs",
+              "version": "4.1.2",
+              "full": "graceful-fs@4.1.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "graceful-fs"
+              ],
+              "__devDependencies": {
+                "mkdirp": "^0.5.0",
+                "rimraf": "^2.2.8",
+                "tap": "^1.2.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/graceful-fs/package.json",
+              "dependencies": {}
+            },
+            "graceful-readlink": {
+              "name": "graceful-readlink",
+              "version": "1.0.1",
+              "full": "graceful-readlink@1.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "graceful-readlink"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/graceful-readlink/package.json",
+              "dependencies": {}
+            },
+            "har-validator": {
+              "name": "har-validator",
+              "version": "2.0.3",
+              "full": "har-validator@2.0.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "har-validator"
+              ],
+              "__devDependencies": {
+                "codeclimate-test-reporter": "0.1.1",
+                "echint": "^1.5.0",
+                "istanbul": "^0.4.0",
+                "mocha": "^2.3.4",
+                "require-directory": "^2.1.1",
+                "should": "^7.1.1",
+                "should-promised": "^0.3.1",
+                "standard": "^5.4.1"
+              },
+              "__dependencies": {
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.3",
+                "pinkie-promise": "^2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/har-validator/package.json",
+              "dependencies": {}
+            },
+            "has-ansi": {
+              "name": "has-ansi",
+              "version": "2.0.0",
+              "full": "has-ansi@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "has-ansi"
+              ],
+              "__devDependencies": {
+                "ava": "0.0.4"
+              },
+              "__dependencies": {
+                "ansi-regex": "^2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/has-ansi/package.json",
+              "dependencies": {}
+            },
+            "has-unicode": {
+              "name": "has-unicode",
+              "version": "1.0.1",
+              "full": "has-unicode@1.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "has-unicode"
+              ],
+              "__devDependencies": {
+                "require-inject": "^1.1.1",
+                "tap": "^0.4.13"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/has-unicode/package.json",
+              "dependencies": {}
+            },
+            "hawk": {
+              "name": "hawk",
+              "version": "3.1.2",
+              "full": "hawk@3.1.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "hawk"
+              ],
+              "__devDependencies": {
+                "code": "1.x.x",
+                "lab": "5.x.x"
+              },
+              "__dependencies": {
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/hawk/package.json",
+              "dependencies": {}
+            },
+            "hoek": {
+              "name": "hoek",
+              "version": "2.16.3",
+              "full": "hoek@2.16.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "hoek"
+              ],
+              "__devDependencies": {
+                "code": "1.x.x",
+                "lab": "5.x.x"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/hoek/package.json",
+              "dependencies": {}
+            },
+            "http-signature": {
+              "name": "http-signature",
+              "version": "1.1.0",
+              "full": "http-signature@1.1.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "http-signature"
+              ],
+              "__devDependencies": {
+                "node-uuid": "^1.4.1",
+                "tap": "0.4.2"
+              },
+              "__dependencies": {
+                "assert-plus": "^0.1.5",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/http-signature/package.json",
+              "dependencies": {}
+            },
+            "inherits": {
+              "name": "inherits",
+              "version": "2.0.1",
+              "full": "inherits@2.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "inherits"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/inherits/package.json",
+              "dependencies": {}
+            },
+            "ini": {
+              "name": "ini",
+              "version": "1.3.4",
+              "full": "ini@1.3.4",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "ini"
+              ],
+              "__devDependencies": {
+                "tap": "^1.2.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/ini/package.json",
+              "dependencies": {}
+            },
+            "is-my-json-valid": {
+              "name": "is-my-json-valid",
+              "version": "2.12.3",
+              "full": "is-my-json-valid@2.12.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "is-my-json-valid"
+              ],
+              "__devDependencies": {
+                "tape": "^2.13.4"
+              },
+              "__dependencies": {
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "2.0.0",
+                "xtend": "^4.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/is-my-json-valid/package.json",
+              "dependencies": {}
+            },
+            "is-property": {
+              "name": "is-property",
+              "version": "1.0.2",
+              "full": "is-property@1.0.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "is-property"
+              ],
+              "__devDependencies": {
+                "tape": "~1.0.4"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/is-property/package.json",
+              "dependencies": {}
+            },
+            "is-typedarray": {
+              "name": "is-typedarray",
+              "version": "1.0.0",
+              "full": "is-typedarray@1.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "is-typedarray"
+              ],
+              "__devDependencies": {
+                "tape": "^2.13.1"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/is-typedarray/package.json",
+              "dependencies": {}
+            },
+            "isarray": {
+              "name": "isarray",
+              "version": "0.0.1",
+              "full": "isarray@0.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "isarray"
+              ],
+              "__devDependencies": {
+                "tap": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/isarray/package.json",
+              "dependencies": {}
+            },
+            "isstream": {
+              "name": "isstream",
+              "version": "0.1.2",
+              "full": "isstream@0.1.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "isstream"
+              ],
+              "__devDependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x",
+                "tape": "~2.12.3"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/isstream/package.json",
+              "dependencies": {}
+            },
+            "jodid25519": {
+              "name": "jodid25519",
+              "version": "1.0.2",
+              "full": "jodid25519@1.0.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "jodid25519"
+              ],
+              "__devDependencies": {
+                "almond": "~0.3.1",
+                "chai": "^3.0.0",
+                "dateformat": "~1.0.7-1.2.3",
+                "ibrik": "~2.0.0",
+                "istanbul": "~0.3.5",
+                "jsdoc": "<=3.3.0",
+                "mocha": "~2.0.1",
+                "sinon": "~1.10.3",
+                "sinon-chai": "^2.8.0"
+              },
+              "__dependencies": {
+                "jsbn": "~0.1.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/jodid25519/package.json",
+              "dependencies": {}
+            },
+            "jsbn": {
+              "name": "jsbn",
+              "version": "0.1.0",
+              "full": "jsbn@0.1.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "jsbn"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/jsbn/package.json",
+              "dependencies": {}
+            },
+            "json-schema": {
+              "name": "json-schema",
+              "version": "0.2.2",
+              "full": "json-schema@0.2.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "AFLv2.1/BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "json-schema"
+              ],
+              "__devDependencies": {
+                "vows": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/json-schema/package.json",
+              "dependencies": {}
+            },
+            "json-stringify-safe": {
+              "name": "json-stringify-safe",
+              "version": "5.0.1",
+              "full": "json-stringify-safe@5.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "json-stringify-safe"
+              ],
+              "__devDependencies": {
+                "mocha": ">= 2.1.0 < 3",
+                "must": ">= 0.12 < 0.13",
+                "sinon": ">= 1.12.2 < 2"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/json-stringify-safe/package.json",
+              "dependencies": {}
+            },
+            "jsonpointer": {
+              "name": "jsonpointer",
+              "version": "2.0.0",
+              "full": "jsonpointer@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "jsonpointer"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/jsonpointer/package.json",
+              "dependencies": {}
+            },
+            "jsprim": {
+              "name": "jsprim",
+              "version": "1.2.2",
+              "full": "jsprim@1.2.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "jsprim"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.2",
+                "verror": "1.3.6"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/jsprim/package.json",
+              "dependencies": {}
+            },
+            "lodash._basetostring": {
+              "name": "lodash._basetostring",
+              "version": "3.0.1",
+              "full": "lodash._basetostring@3.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash._basetostring"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash._basetostring/package.json",
+              "dependencies": {}
+            },
+            "lodash._createpadding": {
+              "name": "lodash._createpadding",
+              "version": "3.6.1",
+              "full": "lodash._createpadding@3.6.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash._createpadding"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "lodash.repeat": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash._createpadding/package.json",
+              "dependencies": {}
+            },
+            "lodash.pad": {
+              "name": "lodash.pad",
+              "version": "3.1.1",
+              "full": "lodash.pad@3.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash.pad"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "lodash._basetostring": "^3.0.0",
+                "lodash._createpadding": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash.pad/package.json",
+              "dependencies": {}
+            },
+            "lodash.padleft": {
+              "name": "lodash.padleft",
+              "version": "3.1.1",
+              "full": "lodash.padleft@3.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash.padleft"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "lodash._basetostring": "^3.0.0",
+                "lodash._createpadding": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash.padleft/package.json",
+              "dependencies": {}
+            },
+            "lodash.padright": {
+              "name": "lodash.padright",
+              "version": "3.1.1",
+              "full": "lodash.padright@3.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash.padright"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "lodash._basetostring": "^3.0.0",
+                "lodash._createpadding": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash.padright/package.json",
+              "dependencies": {}
+            },
+            "lodash.repeat": {
+              "name": "lodash.repeat",
+              "version": "3.0.1",
+              "full": "lodash.repeat@3.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "lodash.repeat"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "lodash._basetostring": "^3.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/lodash.repeat/package.json",
+              "dependencies": {}
+            },
+            "mime-db": {
+              "name": "mime-db",
+              "version": "1.21.0",
+              "full": "mime-db@1.21.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "mime-db"
+              ],
+              "__devDependencies": {
+                "bluebird": "3.1.1",
+                "co": "4.6.0",
+                "cogent": "1.0.1",
+                "csv-parse": "1.0.1",
+                "gnode": "0.1.1",
+                "istanbul": "0.4.1",
+                "mocha": "1.21.5",
+                "raw-body": "2.1.5",
+                "stream-to-array": "2.2.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/mime-db/package.json",
+              "dependencies": {}
+            },
+            "mime-types": {
+              "name": "mime-types",
+              "version": "2.1.9",
+              "full": "mime-types@2.1.9",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "mime-types"
+              ],
+              "__devDependencies": {
+                "istanbul": "0.4.1",
+                "mocha": "~1.21.5"
+              },
+              "__dependencies": {
+                "mime-db": "~1.21.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/mime-types/package.json",
+              "dependencies": {}
+            },
+            "minimist": {
+              "name": "minimist",
+              "version": "0.0.8",
+              "full": "minimist@0.0.8",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "minimist"
+              ],
+              "__devDependencies": {
+                "tap": "~0.4.0",
+                "tape": "~1.0.4"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/minimist/package.json",
+              "dependencies": {}
+            },
+            "mkdirp": {
+              "name": "mkdirp",
+              "version": "0.5.1",
+              "full": "mkdirp@0.5.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "mkdirp"
+              ],
+              "__devDependencies": {
+                "mock-fs": "2 >=2.7.0",
+                "tap": "1"
+              },
+              "__dependencies": {
+                "minimist": "0.0.8"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/mkdirp/package.json",
+              "dependencies": {}
+            },
+            "nan": {
+              "name": "nan",
+              "version": "2.2.0",
+              "full": "nan@2.2.0",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^2.1.0",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "nan"
+              ],
+              "__devDependencies": {
+                "bindings": "~1.2.1",
+                "commander": "^2.8.1",
+                "glob": "^5.0.14",
+                "node-gyp": "~3.0.1",
+                "tap": "~0.7.1",
+                "xtend": "~4.0.0"
+              },
+              "__dependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/nan/package.json",
+              "dependencies": {}
+            },
+            "node-pre-gyp": {
+              "name": "node-pre-gyp",
+              "version": "0.6.19",
+              "full": "node-pre-gyp@0.6.19",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "^0.6.19",
+              "bundled": true,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "node-pre-gyp"
+              ],
+              "__devDependencies": {
+                "aws-sdk": "*",
+                "jshint": "^2.5.10",
+                "mocha": "1.x",
+                "retire": "0.3.x"
+              },
+              "__dependencies": {
+                "mkdirp": "~0.5.0",
+                "nopt": "~3.0.1",
+                "npmlog": "~2.0.0",
+                "rc": "~1.1.0",
+                "request": "2.x",
+                "rimraf": "~2.5.0",
+                "semver": "~5.1.0",
+                "tar": "~2.2.0",
+                "tar-pack": "~3.1.0"
+              },
+              "__optionalDependencies": {},
+              "__bundleDependencies": [
+                "mkdirp",
+                "nopt",
+                "npmlog",
+                "rc",
+                "request",
+                "rimraf",
+                "semver",
+                "tar",
+                "tar-pack"
+              ],
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/node-pre-gyp/package.json",
+              "dependencies": {
+                "nopt": {
+                  "name": "nopt",
+                  "version": "3.0.6",
+                  "full": "nopt@3.0.6",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "ISC",
+                  "dep": "~3.0.1",
+                  "bundled": true,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "node-pre-gyp",
+                    "nopt"
+                  ],
+                  "__devDependencies": {
+                    "tap": "^1.2.0"
+                  },
+                  "__dependencies": {
+                    "abbrev": "1"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/node-pre-gyp/node_modules/nopt/package.json",
+                  "dependencies": {
+                    "abbrev": {
+                      "name": "abbrev",
+                      "version": "1.0.7",
+                      "full": "abbrev@1.0.7",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "node-pre-gyp",
+                        "nopt",
+                        "abbrev"
+                      ],
+                      "__devDependencies": {
+                        "tap": "^1.2.0"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/node-pre-gyp/node_modules/nopt/node_modules/abbrev/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                }
+              }
+            },
+            "node-uuid": {
+              "name": "node-uuid",
+              "version": "1.4.7",
+              "full": "node-uuid@1.4.7",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "node-uuid"
+              ],
+              "__devDependencies": {
+                "nyc": "^2.2.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/node-uuid/package.json",
+              "dependencies": {}
+            },
+            "npmlog": {
+              "name": "npmlog",
+              "version": "2.0.0",
+              "full": "npmlog@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "npmlog"
+              ],
+              "__devDependencies": {
+                "tap": "~2.2.0"
+              },
+              "__dependencies": {
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/npmlog/package.json",
+              "dependencies": {}
+            },
+            "oauth-sign": {
+              "name": "oauth-sign",
+              "version": "0.8.0",
+              "full": "oauth-sign@0.8.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "oauth-sign"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/oauth-sign/package.json",
+              "dependencies": {}
+            },
+            "once": {
+              "name": "once",
+              "version": "1.1.1",
+              "full": "once@1.1.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "once"
+              ],
+              "__devDependencies": {
+                "tap": "~0.3.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/once/package.json",
+              "dependencies": {}
+            },
+            "pinkie": {
+              "name": "pinkie",
+              "version": "2.0.1",
+              "full": "pinkie@2.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "pinkie"
+              ],
+              "__devDependencies": {
+                "core-assert": "^0.1.1",
+                "coveralls": "^2.11.4",
+                "mocha": "*",
+                "nyc": "^3.2.2",
+                "promises-aplus-tests": "*",
+                "xo": "^0.10.1"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/pinkie/package.json",
+              "dependencies": {}
+            },
+            "pinkie-promise": {
+              "name": "pinkie-promise",
+              "version": "2.0.0",
+              "full": "pinkie-promise@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "pinkie-promise"
+              ],
+              "__devDependencies": {
+                "mocha": "*"
+              },
+              "__dependencies": {
+                "pinkie": "^2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/pinkie-promise/package.json",
+              "dependencies": {}
+            },
+            "process-nextick-args": {
+              "name": "process-nextick-args",
+              "version": "1.0.6",
+              "full": "process-nextick-args@1.0.6",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "process-nextick-args"
+              ],
+              "__devDependencies": {
+                "tap": "~0.2.6"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/process-nextick-args/package.json",
+              "dependencies": {}
+            },
+            "qs": {
+              "name": "qs",
+              "version": "5.2.0",
+              "full": "qs@5.2.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "qs"
+              ],
+              "__devDependencies": {
+                "browserify": "^10.2.1",
+                "code": "1.x.x",
+                "lab": "5.x.x"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/qs/package.json",
+              "dependencies": {}
+            },
+            "rc": {
+              "name": "rc",
+              "version": "1.1.6",
+              "full": "rc@1.1.6",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "rc"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~1.0.4"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rc/package.json",
+              "dependencies": {
+                "minimist": {
+                  "name": "minimist",
+                  "version": "1.2.0",
+                  "full": "minimist@1.2.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^1.2.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "rc",
+                    "minimist"
+                  ],
+                  "__devDependencies": {
+                    "covert": "^1.0.0",
+                    "tap": "~0.4.0",
+                    "tape": "^3.5.0"
+                  },
+                  "__dependencies": {},
+                  "__optionalDependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rc/node_modules/minimist/package.json",
+                  "dependencies": {}
+                }
+              }
+            },
+            "readable-stream": {
+              "name": "readable-stream",
+              "version": "2.0.5",
+              "full": "readable-stream@2.0.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "readable-stream"
+              ],
+              "__devDependencies": {
+                "tap": "~0.2.6",
+                "tape": "~4.0.0",
+                "zuul": "~3.0.0"
+              },
+              "__dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/readable-stream/package.json",
+              "dependencies": {}
+            },
+            "request": {
+              "name": "request",
+              "version": "2.67.0",
+              "full": "request@2.67.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "request"
+              ],
+              "__devDependencies": {
+                "bluebird": "^3.0.2",
+                "browserify": "^12.0.1",
+                "browserify-istanbul": "^0.1.5",
+                "buffer-equal": "^0.0.1",
+                "codecov.io": "^0.1.6",
+                "coveralls": "^2.11.4",
+                "eslint": "1.9.0",
+                "function-bind": "^1.0.2",
+                "istanbul": "^0.4.0",
+                "karma": "^0.13.10",
+                "karma-browserify": "^4.4.0",
+                "karma-cli": "^0.1.1",
+                "karma-coverage": "^0.5.3",
+                "karma-phantomjs-launcher": "^0.1.4",
+                "karma-tap": "^1.0.3",
+                "rimraf": "^2.2.8",
+                "server-destroy": "^1.0.1",
+                "tape": "^4.2.0",
+                "taper": "^0.4.0"
+              },
+              "__dependencies": {
+                "aws-sign2": "~0.6.0",
+                "bl": "~1.0.0",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc3",
+                "har-validator": "~2.0.2",
+                "hawk": "~3.1.0",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.0",
+                "qs": "~5.2.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.2.0",
+                "tunnel-agent": "~0.4.1"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/request/package.json",
+              "dependencies": {}
+            },
+            "rimraf": {
+              "name": "rimraf",
+              "version": "2.5.0",
+              "full": "rimraf@2.5.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "rimraf"
+              ],
+              "__devDependencies": {
+                "mkdirp": "^0.5.1",
+                "tap": "^2.3.4"
+              },
+              "__dependencies": {
+                "glob": "^6.0.1"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/package.json",
+              "dependencies": {
+                "glob": {
+                  "name": "glob",
+                  "version": "6.0.3",
+                  "full": "glob@6.0.3",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "ISC",
+                  "dep": "^6.0.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "rimraf",
+                    "glob"
+                  ],
+                  "__devDependencies": {
+                    "mkdirp": "0",
+                    "rimraf": "^2.2.8",
+                    "tap": "^1.1.4",
+                    "tick": "0.0.6"
+                  },
+                  "__dependencies": {
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  },
+                  "__optionalDependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/package.json",
+                  "dependencies": {
+                    "inflight": {
+                      "name": "inflight",
+                      "version": "1.0.4",
+                      "full": "inflight@1.0.4",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "^1.0.4",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "rimraf",
+                        "glob",
+                        "inflight"
+                      ],
+                      "__devDependencies": {
+                        "tap": "^0.4.10"
+                      },
+                      "__dependencies": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                      },
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/inflight/package.json",
+                      "dependencies": {
+                        "wrappy": {
+                          "name": "wrappy",
+                          "version": "1.0.1",
+                          "full": "wrappy@1.0.1",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "1",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "rimraf",
+                            "glob",
+                            "inflight",
+                            "wrappy"
+                          ],
+                          "__devDependencies": {
+                            "tap": "^0.4.12"
+                          },
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/inflight/node_modules/wrappy/package.json",
+                          "dependencies": {}
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "name": "inherits",
+                      "version": "2.0.1",
+                      "full": "inherits@2.0.1",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "2",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "rimraf",
+                        "glob",
+                        "inherits"
+                      ],
+                      "__devDependencies": {},
+                      "__dependencies": {},
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/inherits/package.json",
+                      "dependencies": {}
+                    },
+                    "minimatch": {
+                      "name": "minimatch",
+                      "version": "3.0.0",
+                      "full": "minimatch@3.0.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "2 || 3",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "rimraf",
+                        "glob",
+                        "minimatch"
+                      ],
+                      "__devDependencies": {
+                        "standard": "^3.7.2",
+                        "tap": "^1.2.0"
+                      },
+                      "__dependencies": {
+                        "brace-expansion": "^1.0.0"
+                      },
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/minimatch/package.json",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "name": "brace-expansion",
+                          "version": "1.1.2",
+                          "full": "brace-expansion@1.1.2",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "^1.0.0",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "rimraf",
+                            "glob",
+                            "minimatch",
+                            "brace-expansion"
+                          ],
+                          "__devDependencies": {
+                            "tape": "4.2.2"
+                          },
+                          "__dependencies": {
+                            "balanced-match": "^0.3.0",
+                            "concat-map": "0.0.1"
+                          },
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/package.json",
+                          "dependencies": {
+                            "balanced-match": {
+                              "name": "balanced-match",
+                              "version": "0.3.0",
+                              "full": "balanced-match@0.3.0",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^0.3.0",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "fsevents",
+                                "rimraf",
+                                "glob",
+                                "minimatch",
+                                "brace-expansion",
+                                "balanced-match"
+                              ],
+                              "__devDependencies": {
+                                "tape": "~4.2.2"
+                              },
+                              "__dependencies": {},
+                              "__optionalDependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match/package.json",
+                              "dependencies": {}
+                            },
+                            "concat-map": {
+                              "name": "concat-map",
+                              "version": "0.0.1",
+                              "full": "concat-map@0.0.1",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "0.0.1",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "fsevents",
+                                "rimraf",
+                                "glob",
+                                "minimatch",
+                                "brace-expansion",
+                                "concat-map"
+                              ],
+                              "__devDependencies": {
+                                "tape": "~2.4.0"
+                              },
+                              "__dependencies": {},
+                              "__optionalDependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map/package.json",
+                              "dependencies": {}
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "name": "once",
+                      "version": "1.3.3",
+                      "full": "once@1.3.3",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "^1.3.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "rimraf",
+                        "glob",
+                        "once"
+                      ],
+                      "__devDependencies": {
+                        "tap": "^1.2.0"
+                      },
+                      "__dependencies": {
+                        "wrappy": "1"
+                      },
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/once/package.json",
+                      "dependencies": {
+                        "wrappy": {
+                          "name": "wrappy",
+                          "version": "1.0.1",
+                          "full": "wrappy@1.0.1",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "1",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "rimraf",
+                            "glob",
+                            "once",
+                            "wrappy"
+                          ],
+                          "__devDependencies": {
+                            "tap": "^0.4.12"
+                          },
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/once/node_modules/wrappy/package.json",
+                          "dependencies": {}
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "name": "path-is-absolute",
+                      "version": "1.0.0",
+                      "full": "path-is-absolute@1.0.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^1.0.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "rimraf",
+                        "glob",
+                        "path-is-absolute"
+                      ],
+                      "__devDependencies": {},
+                      "__dependencies": {},
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/rimraf/node_modules/glob/node_modules/path-is-absolute/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "name": "semver",
+              "version": "5.1.0",
+              "full": "semver@5.1.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "semver"
+              ],
+              "__devDependencies": {
+                "tap": "^2.0.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/semver/package.json",
+              "dependencies": {}
+            },
+            "sntp": {
+              "name": "sntp",
+              "version": "1.0.9",
+              "full": "sntp@1.0.9",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "sntp"
+              ],
+              "__devDependencies": {
+                "lab": "4.x.x"
+              },
+              "__dependencies": {
+                "hoek": "2.x.x"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/sntp/package.json",
+              "dependencies": {}
+            },
+            "sshpk": {
+              "name": "sshpk",
+              "version": "1.7.2",
+              "full": "sshpk@1.7.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "sshpk"
+              ],
+              "__devDependencies": {
+                "benchmark": ">=1.0.0 <2.0.0",
+                "sinon": ">=1.17.2 <2.0.0",
+                "tape": ">=3.5.0 <4.0.0",
+                "temp": "0.8.2"
+              },
+              "__dependencies": {
+                "asn1": ">=0.2.3 <0.3.0",
+                "assert-plus": ">=0.2.0 <0.3.0",
+                "dashdash": ">=1.10.1 <2.0.0",
+                "ecc-jsbn": ">=0.0.1 <1.0.0",
+                "jodid25519": ">=1.0.0 <2.0.0",
+                "jsbn": ">=0.1.0 <0.2.0",
+                "tweetnacl": ">=0.13.0 <1.0.0"
+              },
+              "__optionalDependencies": {
+                "ecc-jsbn": ">=0.0.1 <1.0.0",
+                "jodid25519": ">=1.0.0 <2.0.0",
+                "jsbn": ">=0.1.0 <0.2.0",
+                "tweetnacl": ">=0.13.0 <1.0.0"
+              },
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/sshpk/package.json",
+              "dependencies": {
+                "assert-plus": {
+                  "name": "assert-plus",
+                  "version": "0.2.0",
+                  "full": "assert-plus@0.2.0",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": ">=0.2.0 <0.3.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "sshpk",
+                    "assert-plus"
+                  ],
+                  "__devDependencies": {
+                    "faucet": "0.0.1",
+                    "tape": "4.2.2"
+                  },
+                  "__dependencies": {},
+                  "__optionalDependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/sshpk/node_modules/assert-plus/package.json",
+                  "dependencies": {}
+                }
+              }
+            },
+            "string_decoder": {
+              "name": "string_decoder",
+              "version": "0.10.31",
+              "full": "string_decoder@0.10.31",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "string_decoder"
+              ],
+              "__devDependencies": {
+                "tap": "~0.4.8"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/string_decoder/package.json",
+              "dependencies": {}
+            },
+            "stringstream": {
+              "name": "stringstream",
+              "version": "0.0.5",
+              "full": "stringstream@0.0.5",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "stringstream"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/stringstream/package.json",
+              "dependencies": {}
+            },
+            "strip-ansi": {
+              "name": "strip-ansi",
+              "version": "3.0.0",
+              "full": "strip-ansi@3.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "strip-ansi"
+              ],
+              "__devDependencies": {
+                "ava": "0.0.4"
+              },
+              "__dependencies": {
+                "ansi-regex": "^2.0.0"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/strip-ansi/package.json",
+              "dependencies": {}
+            },
+            "strip-json-comments": {
+              "name": "strip-json-comments",
+              "version": "1.0.4",
+              "full": "strip-json-comments@1.0.4",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "strip-json-comments"
+              ],
+              "__devDependencies": {
+                "mocha": "*"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/strip-json-comments/package.json",
+              "dependencies": {}
+            },
+            "supports-color": {
+              "name": "supports-color",
+              "version": "2.0.0",
+              "full": "supports-color@2.0.0",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "supports-color"
+              ],
+              "__devDependencies": {
+                "mocha": "*",
+                "require-uncached": "^1.0.2"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/supports-color/package.json",
+              "dependencies": {}
+            },
+            "tar": {
+              "name": "tar",
+              "version": "2.2.1",
+              "full": "tar@2.2.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "tar"
+              ],
+              "__devDependencies": {
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "rimraf": "1.x",
+                "tap": "0.x"
+              },
+              "__dependencies": {
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar/package.json",
+              "dependencies": {}
+            },
+            "tar-pack": {
+              "name": "tar-pack",
+              "version": "3.1.2",
+              "full": "tar-pack@3.1.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "tar-pack"
+              ],
+              "__devDependencies": {
+                "mkdirp": "*",
+                "mocha": "*",
+                "rfile": "*"
+              },
+              "__dependencies": {
+                "debug": "~0.7.2",
+                "fstream": "~1.0.8",
+                "fstream-ignore": "~1.0.3",
+                "once": "~1.1.1",
+                "readable-stream": "~2.0.4",
+                "rimraf": "~2.4.4",
+                "tar": "~2.2.1",
+                "uid-number": "0.0.3"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/package.json",
+              "dependencies": {
+                "rimraf": {
+                  "name": "rimraf",
+                  "version": "2.4.5",
+                  "full": "rimraf@2.4.5",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "ISC",
+                  "dep": "~2.4.4",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "fsevents",
+                    "tar-pack",
+                    "rimraf"
+                  ],
+                  "__devDependencies": {
+                    "mkdirp": "^0.5.1",
+                    "tap": "^2.3.4"
+                  },
+                  "__dependencies": {
+                    "glob": "^6.0.1"
+                  },
+                  "__optionalDependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/package.json",
+                  "dependencies": {
+                    "glob": {
+                      "name": "glob",
+                      "version": "6.0.3",
+                      "full": "glob@6.0.3",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "ISC",
+                      "dep": "^6.0.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "fsevents",
+                        "tar-pack",
+                        "rimraf",
+                        "glob"
+                      ],
+                      "__devDependencies": {
+                        "mkdirp": "0",
+                        "rimraf": "^2.2.8",
+                        "tap": "^1.1.4",
+                        "tick": "0.0.6"
+                      },
+                      "__dependencies": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                      },
+                      "__optionalDependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/package.json",
+                      "dependencies": {
+                        "inflight": {
+                          "name": "inflight",
+                          "version": "1.0.4",
+                          "full": "inflight@1.0.4",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "^1.0.4",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "tar-pack",
+                            "rimraf",
+                            "glob",
+                            "inflight"
+                          ],
+                          "__devDependencies": {
+                            "tap": "^0.4.10"
+                          },
+                          "__dependencies": {
+                            "once": "^1.3.0",
+                            "wrappy": "1"
+                          },
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/inflight/package.json",
+                          "dependencies": {
+                            "wrappy": {
+                              "name": "wrappy",
+                              "version": "1.0.1",
+                              "full": "wrappy@1.0.1",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "ISC",
+                              "dep": "1",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "fsevents",
+                                "tar-pack",
+                                "rimraf",
+                                "glob",
+                                "inflight",
+                                "wrappy"
+                              ],
+                              "__devDependencies": {
+                                "tap": "^0.4.12"
+                              },
+                              "__dependencies": {},
+                              "__optionalDependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/inflight/node_modules/wrappy/package.json",
+                              "dependencies": {}
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "name": "inherits",
+                          "version": "2.0.1",
+                          "full": "inherits@2.0.1",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "2",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "tar-pack",
+                            "rimraf",
+                            "glob",
+                            "inherits"
+                          ],
+                          "__devDependencies": {},
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/inherits/package.json",
+                          "dependencies": {}
+                        },
+                        "minimatch": {
+                          "name": "minimatch",
+                          "version": "3.0.0",
+                          "full": "minimatch@3.0.0",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "2 || 3",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "tar-pack",
+                            "rimraf",
+                            "glob",
+                            "minimatch"
+                          ],
+                          "__devDependencies": {
+                            "standard": "^3.7.2",
+                            "tap": "^1.2.0"
+                          },
+                          "__dependencies": {
+                            "brace-expansion": "^1.0.0"
+                          },
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/minimatch/package.json",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "name": "brace-expansion",
+                              "version": "1.1.2",
+                              "full": "brace-expansion@1.1.2",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "MIT",
+                              "dep": "^1.0.0",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "fsevents",
+                                "tar-pack",
+                                "rimraf",
+                                "glob",
+                                "minimatch",
+                                "brace-expansion"
+                              ],
+                              "__devDependencies": {
+                                "tape": "4.2.2"
+                              },
+                              "__dependencies": {
+                                "balanced-match": "^0.3.0",
+                                "concat-map": "0.0.1"
+                              },
+                              "__optionalDependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/package.json",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "name": "balanced-match",
+                                  "version": "0.3.0",
+                                  "full": "balanced-match@0.3.0",
+                                  "valid": true,
+                                  "depType": "prod",
+                                  "snyk": false,
+                                  "license": "MIT",
+                                  "dep": "^0.3.0",
+                                  "bundled": false,
+                                  "__from": [
+                                    "foo",
+                                    "chokidar",
+                                    "fsevents",
+                                    "tar-pack",
+                                    "rimraf",
+                                    "glob",
+                                    "minimatch",
+                                    "brace-expansion",
+                                    "balanced-match"
+                                  ],
+                                  "__devDependencies": {
+                                    "tape": "~4.2.2"
+                                  },
+                                  "__dependencies": {},
+                                  "__optionalDependencies": {},
+                                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match/package.json",
+                                  "dependencies": {}
+                                },
+                                "concat-map": {
+                                  "name": "concat-map",
+                                  "version": "0.0.1",
+                                  "full": "concat-map@0.0.1",
+                                  "valid": true,
+                                  "depType": "prod",
+                                  "snyk": false,
+                                  "license": "MIT",
+                                  "dep": "0.0.1",
+                                  "bundled": false,
+                                  "__from": [
+                                    "foo",
+                                    "chokidar",
+                                    "fsevents",
+                                    "tar-pack",
+                                    "rimraf",
+                                    "glob",
+                                    "minimatch",
+                                    "brace-expansion",
+                                    "concat-map"
+                                  ],
+                                  "__devDependencies": {
+                                    "tape": "~2.4.0"
+                                  },
+                                  "__dependencies": {},
+                                  "__optionalDependencies": {},
+                                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map/package.json",
+                                  "dependencies": {}
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "name": "once",
+                          "version": "1.3.3",
+                          "full": "once@1.3.3",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "ISC",
+                          "dep": "^1.3.0",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "tar-pack",
+                            "rimraf",
+                            "glob",
+                            "once"
+                          ],
+                          "__devDependencies": {
+                            "tap": "^1.2.0"
+                          },
+                          "__dependencies": {
+                            "wrappy": "1"
+                          },
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/once/package.json",
+                          "dependencies": {
+                            "wrappy": {
+                              "name": "wrappy",
+                              "version": "1.0.1",
+                              "full": "wrappy@1.0.1",
+                              "valid": true,
+                              "depType": "prod",
+                              "snyk": false,
+                              "license": "ISC",
+                              "dep": "1",
+                              "bundled": false,
+                              "__from": [
+                                "foo",
+                                "chokidar",
+                                "fsevents",
+                                "tar-pack",
+                                "rimraf",
+                                "glob",
+                                "once",
+                                "wrappy"
+                              ],
+                              "__devDependencies": {
+                                "tap": "^0.4.12"
+                              },
+                              "__dependencies": {},
+                              "__optionalDependencies": {},
+                              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/once/node_modules/wrappy/package.json",
+                              "dependencies": {}
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "name": "path-is-absolute",
+                          "version": "1.0.0",
+                          "full": "path-is-absolute@1.0.0",
+                          "valid": true,
+                          "depType": "prod",
+                          "snyk": false,
+                          "license": "MIT",
+                          "dep": "^1.0.0",
+                          "bundled": false,
+                          "__from": [
+                            "foo",
+                            "chokidar",
+                            "fsevents",
+                            "tar-pack",
+                            "rimraf",
+                            "glob",
+                            "path-is-absolute"
+                          ],
+                          "__devDependencies": {},
+                          "__dependencies": {},
+                          "__optionalDependencies": {},
+                          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tar-pack/node_modules/rimraf/node_modules/glob/node_modules/path-is-absolute/package.json",
+                          "dependencies": {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tough-cookie": {
+              "name": "tough-cookie",
+              "version": "2.2.1",
+              "full": "tough-cookie@2.2.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD-3-Clause",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "tough-cookie"
+              ],
+              "__devDependencies": {
+                "async": "^1.4.2",
+                "vows": "^0.8.1"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tough-cookie/package.json",
+              "dependencies": {}
+            },
+            "tunnel-agent": {
+              "name": "tunnel-agent",
+              "version": "0.4.2",
+              "full": "tunnel-agent@0.4.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "Apache-2.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "tunnel-agent"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tunnel-agent/package.json",
+              "dependencies": {}
+            },
+            "tweetnacl": {
+              "name": "tweetnacl",
+              "version": "0.13.2",
+              "full": "tweetnacl@0.13.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "CC0-1.0",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "tweetnacl"
+              ],
+              "__devDependencies": {
+                "browserify": "^10.1.3",
+                "eslint": "^1.4.3",
+                "faucet": "0.0.1",
+                "tap-browser-color": "^0.1.2",
+                "tape": "^4.0.0",
+                "testling": "^1.7.1",
+                "uglify-js": "^2.4.21"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/tweetnacl/package.json",
+              "dependencies": {}
+            },
+            "uid-number": {
+              "name": "uid-number",
+              "version": "0.0.3",
+              "full": "uid-number@0.0.3",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "BSD",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "uid-number"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/uid-number/package.json",
+              "dependencies": {}
+            },
+            "util-deprecate": {
+              "name": "util-deprecate",
+              "version": "1.0.2",
+              "full": "util-deprecate@1.0.2",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "util-deprecate"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/util-deprecate/package.json",
+              "dependencies": {}
+            },
+            "verror": {
+              "name": "verror",
+              "version": "1.3.6",
+              "full": "verror@1.3.6",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "none",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "verror"
+              ],
+              "__devDependencies": {},
+              "__dependencies": {
+                "extsprintf": "1.0.2"
+              },
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/verror/package.json",
+              "dependencies": {}
+            },
+            "xtend": {
+              "name": "xtend",
+              "version": "4.0.1",
+              "full": "xtend@4.0.1",
+              "valid": false,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "unknown",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "fsevents",
+                "xtend"
+              ],
+              "__devDependencies": {
+                "tape": "~1.1.0"
+              },
+              "__dependencies": {},
+              "__optionalDependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/fsevents/node_modules/xtend/package.json",
+              "dependencies": {}
+            }
+          }
+        },
+        "glob-parent": {
+          "name": "glob-parent",
+          "version": "2.0.0",
+          "full": "glob-parent@2.0.0",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "ISC",
+          "dep": "^2.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "glob-parent"
+          ],
+          "__devDependencies": {
+            "coveralls": "^2.11.2",
+            "istanbul": "^0.3.5",
+            "mocha": "^2.1.0"
+          },
+          "__dependencies": {
+            "is-glob": "^2.0.0"
+          },
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/glob-parent/package.json",
+          "dependencies": {}
+        },
+        "inherits": {
+          "name": "inherits",
+          "version": "2.0.1",
+          "full": "inherits@2.0.1",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "ISC",
+          "dep": "^2.0.1",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "inherits"
+          ],
+          "__devDependencies": {},
+          "__dependencies": {},
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/inherits/package.json",
+          "dependencies": {}
+        },
+        "is-binary-path": {
+          "name": "is-binary-path",
+          "version": "1.0.1",
+          "full": "is-binary-path@1.0.1",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^1.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "is-binary-path"
+          ],
+          "__devDependencies": {
+            "ava": "0.0.4"
+          },
+          "__dependencies": {
+            "binary-extensions": "^1.0.0"
+          },
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/is-binary-path/package.json",
+          "dependencies": {
+            "binary-extensions": {
+              "name": "binary-extensions",
+              "version": "1.4.0",
+              "full": "binary-extensions@1.4.0",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^1.0.0",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "is-binary-path",
+                "binary-extensions"
+              ],
+              "__devDependencies": {
+                "ava": "0.0.4"
+              },
+              "__dependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/is-binary-path/node_modules/binary-extensions/package.json",
+              "dependencies": {}
+            }
+          }
+        },
+        "is-glob": {
+          "name": "is-glob",
+          "version": "2.0.1",
+          "full": "is-glob@2.0.1",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^2.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "is-glob"
+          ],
+          "__devDependencies": {
+            "mocha": "*"
+          },
+          "__dependencies": {
+            "is-extglob": "^1.0.0"
+          },
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/is-glob/package.json",
+          "dependencies": {
+            "is-extglob": {
+              "name": "is-extglob",
+              "version": "1.0.0",
+              "full": "is-extglob@1.0.0",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^1.0.0",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "is-glob",
+                "is-extglob"
+              ],
+              "__devDependencies": {
+                "mocha": "*",
+                "should": "*"
+              },
+              "__dependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/is-glob/node_modules/is-extglob/package.json",
+              "dependencies": {}
+            }
+          }
+        },
+        "path-is-absolute": {
+          "name": "path-is-absolute",
+          "version": "1.0.0",
+          "full": "path-is-absolute@1.0.0",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^1.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "path-is-absolute"
+          ],
+          "__devDependencies": {},
+          "__dependencies": {},
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/path-is-absolute/package.json",
+          "dependencies": {}
+        },
+        "readdirp": {
+          "name": "readdirp",
+          "version": "2.0.0",
+          "full": "readdirp@2.0.0",
+          "valid": true,
+          "depType": "prod",
+          "snyk": false,
+          "license": "MIT",
+          "dep": "^2.0.0",
+          "bundled": false,
+          "__from": [
+            "foo",
+            "chokidar",
+            "readdirp"
+          ],
+          "__devDependencies": {
+            "nave": "^0.5.1",
+            "tap": "^1.3.2",
+            "through2": "^2.0.0"
+          },
+          "__dependencies": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^2.0.10",
+            "readable-stream": "^2.0.2"
+          },
+          "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/package.json",
+          "dependencies": {
+            "graceful-fs": {
+              "name": "graceful-fs",
+              "version": "4.1.3",
+              "full": "graceful-fs@4.1.3",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "^4.1.2",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "readdirp",
+                "graceful-fs"
+              ],
+              "__devDependencies": {
+                "mkdirp": "^0.5.0",
+                "rimraf": "^2.2.8",
+                "tap": "^5.4.2"
+              },
+              "__dependencies": {},
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/graceful-fs/package.json",
+              "dependencies": {}
+            },
+            "minimatch": {
+              "name": "minimatch",
+              "version": "2.0.10",
+              "full": "minimatch@2.0.10",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "ISC",
+              "dep": "^2.0.10",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "readdirp",
+                "minimatch"
+              ],
+              "__devDependencies": {
+                "browserify": "^9.0.3",
+                "standard": "^3.7.2",
+                "tap": "^1.2.0"
+              },
+              "__dependencies": {
+                "brace-expansion": "^1.0.0"
+              },
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/minimatch/package.json",
+              "dependencies": {
+                "brace-expansion": {
+                  "name": "brace-expansion",
+                  "version": "1.1.3",
+                  "full": "brace-expansion@1.1.3",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "^1.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "minimatch",
+                    "brace-expansion"
+                  ],
+                  "__devDependencies": {
+                    "tape": "4.4.0"
+                  },
+                  "__dependencies": {
+                    "balanced-match": "^0.3.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/minimatch/node_modules/brace-expansion/package.json",
+                  "dependencies": {
+                    "balanced-match": {
+                      "name": "balanced-match",
+                      "version": "0.3.0",
+                      "full": "balanced-match@0.3.0",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "^0.3.0",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "readdirp",
+                        "minimatch",
+                        "brace-expansion",
+                        "balanced-match"
+                      ],
+                      "__devDependencies": {
+                        "tape": "~4.2.2"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/minimatch/node_modules/brace-expansion/node_modules/balanced-match/package.json",
+                      "dependencies": {}
+                    },
+                    "concat-map": {
+                      "name": "concat-map",
+                      "version": "0.0.1",
+                      "full": "concat-map@0.0.1",
+                      "valid": true,
+                      "depType": "prod",
+                      "snyk": false,
+                      "license": "MIT",
+                      "dep": "0.0.1",
+                      "bundled": false,
+                      "__from": [
+                        "foo",
+                        "chokidar",
+                        "readdirp",
+                        "minimatch",
+                        "brace-expansion",
+                        "concat-map"
+                      ],
+                      "__devDependencies": {
+                        "tape": "~2.4.0"
+                      },
+                      "__dependencies": {},
+                      "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/minimatch/node_modules/brace-expansion/node_modules/concat-map/package.json",
+                      "dependencies": {}
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "name": "readable-stream",
+              "version": "2.0.5",
+              "full": "readable-stream@2.0.5",
+              "valid": true,
+              "depType": "prod",
+              "snyk": false,
+              "license": "MIT",
+              "dep": "^2.0.2",
+              "bundled": false,
+              "__from": [
+                "foo",
+                "chokidar",
+                "readdirp",
+                "readable-stream"
+              ],
+              "__devDependencies": {
+                "tap": "~0.2.6",
+                "tape": "~4.0.0",
+                "zuul": "~3.0.0"
+              },
+              "__dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              },
+              "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/package.json",
+              "dependencies": {
+                "core-util-is": {
+                  "name": "core-util-is",
+                  "version": "1.0.2",
+                  "full": "core-util-is@1.0.2",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "~1.0.0",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "readable-stream",
+                    "core-util-is"
+                  ],
+                  "__devDependencies": {
+                    "tap": "^2.3.0"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/node_modules/core-util-is/package.json",
+                  "dependencies": {}
+                },
+                "isarray": {
+                  "name": "isarray",
+                  "version": "0.0.1",
+                  "full": "isarray@0.0.1",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "0.0.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "readable-stream",
+                    "isarray"
+                  ],
+                  "__devDependencies": {
+                    "tap": "*"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/node_modules/isarray/package.json",
+                  "dependencies": {}
+                },
+                "process-nextick-args": {
+                  "name": "process-nextick-args",
+                  "version": "1.0.6",
+                  "full": "process-nextick-args@1.0.6",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "~1.0.6",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "readable-stream",
+                    "process-nextick-args"
+                  ],
+                  "__devDependencies": {
+                    "tap": "~0.2.6"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/node_modules/process-nextick-args/package.json",
+                  "dependencies": {}
+                },
+                "string_decoder": {
+                  "name": "string_decoder",
+                  "version": "0.10.31",
+                  "full": "string_decoder@0.10.31",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "~0.10.x",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "readable-stream",
+                    "string_decoder"
+                  ],
+                  "__devDependencies": {
+                    "tap": "~0.4.8"
+                  },
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/node_modules/string_decoder/package.json",
+                  "dependencies": {}
+                },
+                "util-deprecate": {
+                  "name": "util-deprecate",
+                  "version": "1.0.2",
+                  "full": "util-deprecate@1.0.2",
+                  "valid": true,
+                  "depType": "prod",
+                  "snyk": false,
+                  "license": "MIT",
+                  "dep": "~1.0.1",
+                  "bundled": false,
+                  "__from": [
+                    "foo",
+                    "chokidar",
+                    "readdirp",
+                    "readable-stream",
+                    "util-deprecate"
+                  ],
+                  "__devDependencies": {},
+                  "__dependencies": {},
+                  "__filename": "/Users/remy/Sites/snyk-tests/foo/node_modules/chokidar/node_modules/readdirp/node_modules/readable-stream/node_modules/util-deprecate/package.json",
+                  "dependencies": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Because I missed the `from.slice(0)` cloning technique, when the `findPackage` ran, it was reducing the size of `from` (since we're passing a ref) and [`while (from.pop())`](https://github.com/Snyk/resolve-deps/blob/c56c8b8ada00b55716fb7edfe74c983c9bcef93b/lib/pluck.js#L46) return `false`.
