### PR TITLE
test: unsupported git urls

### DIFF
--- a/lib/pluck.js
+++ b/lib/pluck.js
@@ -3,6 +3,7 @@ module.exports = pluck;
 var semver = require('semver');
 var moduleToObject = require('snyk-module');
 var debug = require('debug')('snyk:resolve:pluck');
+var parseOptions = { loose: true };
 
 function pluck(root, path, name, range) {
   if (range === 'latest') {
@@ -13,7 +14,7 @@ function pluck(root, path, name, range) {
   // note that we don't need the first item in the path (which is the root
   // package name).
   var from = path.slice(0);
-  var rootPath = moduleToObject(from.shift()).name;
+  var rootPath = moduleToObject(from.shift(), parseOptions).name;
 
   // if the root of the virtual tree doesn't even match our path, bail out
   if (rootPath !== root.name) {
@@ -22,7 +23,8 @@ function pluck(root, path, name, range) {
 
   // do a check to see if the last item in the path is actually the package
   // we're looking for, and if it's not, push it on
-  if (from.length !== 0 && moduleToObject(from.slice(-1).pop()).name === name) {
+  if (from.length !== 0 &&
+      moduleToObject(from.slice(-1).pop(), parseOptions).name === name) {
     from.pop();
   }
 
@@ -37,7 +39,7 @@ function pluck(root, path, name, range) {
   var realPath = [];
 
   while (from.length) {
-    var pkg = moduleToObject(from[0]);
+    var pkg = moduleToObject(from[0], parseOptions);
     var test = getMatch(leaf, pkg.name, pkg.version);
 
     if (test) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "proxyquire": "^1.7.4",
     "semantic-release": "^4.3.5",
     "sinon": "^1.17.3",
-    "snyk-resolve-deps-fixtures": "^1.1.5",
+    "snyk-resolve-deps-fixtures": "^1.1.6",
     "tap": "^5.1.1",
     "tap-only": "0.0.5",
     "tape": "^4.4.0"
@@ -38,7 +38,7 @@
     "lru-cache": "^4.0.0",
     "minimist": "^1.2.0",
     "semver": "^5.1.0",
-    "snyk-module": "^1.5.0",
+    "snyk-module": "^1.6.0",
     "snyk-resolve": "^1.0.0",
     "snyk-tree": "^1.0.0",
     "snyk-try-require": "^1.1.1",

--- a/test/pluck.test.js
+++ b/test/pluck.test.js
@@ -1,10 +1,12 @@
 var test = require('tap-only');
 var pluck = require('../lib/pluck');
 var path = require('path');
-var npm2fixtures = require(path.resolve(__dirname, '..',
-    'node_modules/snyk-resolve-deps-fixtures/snyk-resolve-deps-npm2.json'));
-var npm3fixtures = require(path.resolve(__dirname, '..',
-    'node_modules/snyk-resolve-deps-fixtures/snyk-resolve-deps-npm3.json'));
+var remoteFixtures = path.resolve(__dirname, '..',
+    'node_modules/snyk-resolve-deps-fixtures/');
+console.log(remoteFixtures);
+var npm2fixtures = require(remoteFixtures + '/snyk-resolve-deps-npm2.json');
+var npm3fixtures = require(remoteFixtures + '/snyk-resolve-deps-npm3.json');
+var pm2fixtures = require(remoteFixtures + '/pm2-disk.json');
 var logicalTree = require('../lib/logical');
 
 test('pluck (with npm@2 modules)', function (t) {
@@ -154,5 +156,15 @@ test('shrinkwrap compatible (finds all vuln shrinkwrap)', function (t) {
     t.equal(plucked.version, '2.11.0', vuln.id + ': was able to pluck from shrinkwrap');
     t.equal(plucked.shrinkwrap, 'hapi@13.0.0', vuln.id + ': shrinkwrap detected');
   });
+  t.end();
+});
+
+test('handles unsupported git urls', function (t) {
+  var from = [ 'pm2-demo@1.0.0', 'pm2@1.0.1' ];
+
+  var plucked;
+  plucked = pluck(pm2fixtures, from, 'ikt', 'git+http://ikt.pm2.io/ikt.git#master');
+  t.equal(plucked.name, 'ikt', 'was able to pluck from unsupported git url');
+
   t.end();
 });


### PR DESCRIPTION
- [x] Reviewed by @grnd 
#### What's this PR do?

Using the latest snyk-module, we are able to pluck modules with non-supported versions, in particular non-supported git urls.

Fixes https://github.com/Snyk/snyk/issues/16

I could have wrapped in a try/catch, but it would have created a new try/catch many, many, many times, and IIRC there's a perf overhead to try/catch. This `loose` flag allows us to [parse a package string without it failing](https://github.com/Snyk/module/commit/48cf10db9cc1c484dc1fe18ba879bfd6e2db2cba).
#### What are the relevant tickets?

https://github.com/Snyk/snyk/issues/16
