### PR TITLE
permit pkg.json extra field extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Note that the output differs from the `npm ls` output in that deduped packages a
 ```js
 var resolveDeps = require('snyk-resolve-deps');
 var asTree = require('snyk-tree');
+var options = { dev: true };
 
-resolveDeps(process.cwd(), { dev: true }).then(function (tree) {
+resolveDeps(process.cwd(), options).then(function (tree) {
   console.log(asTree(tree));
 }).catch(function (error) {
   // error is usually limited to unknown directory
@@ -18,6 +19,15 @@ resolveDeps(process.cwd(), { dev: true }).then(function (tree) {
   process.exit(1);
 });
 ```
+
+### API
+
+#### resolveDeps(root, options)
+
+- root: path to project root
+- options (optional)
+  - dev: [default, `false`] report only development options
+  - extraFields: [default, `undefined`] extract extra fields from dependencies' package.json files. example: `['files']`
 
 ## CLI usage
 

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -10,10 +10,24 @@ var semver = require('semver');
 var resolve = require('snyk-resolve');
 var tryRequire = require('snyk-try-require');
 
+function applyExtraFields(src, dest, extraFields) {
+  if (!extraFields || !extraFields.length) {
+    return;
+  }
+  extraFields.forEach(function applyExtraField(field) {
+    _.set(dest, field, _.get(src, field) || null);
+  });
+};
+
 // FIXME only supports dependancies & dev deps not opt-deps
-function loadModules(root, depType) {
+function loadModules(root, depType, options) {
   tryRequire.cache.reset(); // reset the package cache on re-run
-  return loadModulesInternal(root, depType || null).then(function (tree) {
+  return loadModulesInternal(
+    root,
+    depType || null,
+    null,
+    options
+  ).then(function (tree) {
     // ensure there's no missing packages our known root deps
     var missing = [];
     if (tree.__dependencies) {
@@ -47,7 +61,8 @@ function loadModules(root, depType) {
 
 }
 
-function loadModulesInternal(root, rootDepType, parent) {
+function loadModulesInternal(root, rootDepType, parent, options) {
+  options = options || {}
   if (!rootDepType) {
     rootDepType = depTypes.EXTRANEOUS;
   }
@@ -63,7 +78,9 @@ function loadModulesInternal(root, rootDepType, parent) {
     // if there's a package found, collect this information too
     if (pkg) {
       var full = pkg.name + '@' + (pkg.version || '0.0.0');
-      modules = {
+      modules = {};
+      applyExtraFields(pkg, modules, options.extraFields);
+      _.assign(modules, {
         name: pkg.name,
         version: pkg.version || null,
         license: pkg.license || 'none',
@@ -77,7 +94,7 @@ function loadModulesInternal(root, rootDepType, parent) {
         __optionalDependencies: pkg.optionalDependencies,
         __bundleDependencies: pkg.bundleDependencies,
         __filename: pkg.__filename,
-      };
+      });
 
       // allows us to add to work out the full path that the package was
       // introduced via
@@ -155,8 +172,9 @@ function loadModulesInternal(root, rootDepType, parent) {
           }
 
           var full = curr.name + '@' + (curr.version || '0.0.0');
-
-          acc[curr.name] = {
+          acc[curr.name] = {}
+          applyExtraFields(curr, acc[curr.name], options.extraFields);
+          _.assign(acc[curr.name], {
             name: curr.name,
             version: curr.version || null,
             full: full,
@@ -172,7 +190,7 @@ function loadModulesInternal(root, rootDepType, parent) {
             __optionalDependencies: curr.optionalDependencies,
             __bundleDependencies: curr.bundleDependencies,
             __filename: curr.__filename,
-          };
+          });
 
           if (depInfo.bundled) {
             acc[curr.name].bundled = acc[curr.name].__from.slice(0);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 module.exports = function (dir, options) {
-  return physicalTree(dir).then(function (res) {
+  return physicalTree(dir, null, options).then(function (res) {
     return logicalTree(res, options);
   });
 };

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -41,7 +41,6 @@ test('deps - with extraFields', function (t) {
   }).catch(function (e) {
     t.fail(e.stack);
   }).then(t.end);
-
 });
 
 test('deps - throws without path', function (t) {

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -32,6 +32,15 @@ test('deps - with uglify-package', function (t) {
   }).catch(function (e) {
     t.fail(e.stack);
   }).then(t.end);
+});
+
+test('deps - with extraFields', function (t) {
+  deps(npm2fixture, null, { extraFields: [ 'main', 'super-bogus-field' ]}).then(function (res) {
+    t.equal(res.main, 'index.js', 'includes extraFields');
+    t.equal(res['super-bogus-field'], null, 'produces null for empty extraFields fields');
+  }).catch(function (e) {
+    t.fail(e.stack);
+  }).then(t.end);
 
 });
 


### PR DESCRIPTION
# problem statement
- i need more fields from my package.json when doing dep reports than reported by default
# solution
- permit specifying `extraFields` 
# discussion
- please feel free to rename `extraFields` any way seen fit. not attached to the API name, just the functionality
- _great code_ guys.  seriously, excellent work.  very readable.  i was able to get in and get out no problem.  some API docs or doc blocks _could_ be handy, but thank you regardless :)  the `deps.js` file methods are pretty long and could be broken up some, but hey, 👍 
