### PR TITLE
chore: update travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,10 @@ cache:
     - node_modules
 notifications:
   email: true
-  webhooks: https://coveralls.io/webhook?repo_token=${COVERALLS_REPO_TOKEN}
 node_js:
+  - '8'
   - '6'
   - '4'
-before_install: |
-  case ${TRAVIS_NODE_VERSION} in
-    5)
-      echo "Keeping npm@3...hopefully"
-      ;;
-    *)
-      npm install -g npm@^2.0.0
-      echo "npm@2 installed"
-      ;;
-  esac
-  echo ${TRAVIS_NODE_VERSION}
 after_success:
   # custom travis_after_all script under @remy's private gist
   - 'curl -Lo travis_after_all.py https://git.io/vzaBe'

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -21,7 +21,12 @@ test('deps - npm@3', function (t) {
   }).catch(t.fail).then(t.end);
 });
 
-test('deps - with uglify-package', function (t) {
+// fixture uglify-package does not exist, and newer versions of npm care
+const legacyNpm = Number(
+  require('child_process').execSync('npm -v').toString().split('.', 1)[0]
+) < 5;
+
+legacyNpm && test('deps - with uglify-package', function (t) {
   deps(npm2fixture).then(function (res) {
     t.equal(res.name, 'uglify-package', 'package name matches');
     t.type(res.dependencies, 'object', 'has dependencies');
@@ -34,7 +39,7 @@ test('deps - with uglify-package', function (t) {
   }).then(t.end);
 });
 
-test('deps - with extraFields', function (t) {
+legacyNpm && test('deps - with extraFields', function (t) {
   deps(npm2fixture, null, { extraFields: [ 'main', 'super-bogus-field' ]}).then(function (res) {
     t.equal(res.main, 'index.js', 'includes extraFields');
     t.equal(res['super-bogus-field'], null, 'produces null for empty extraFields fields');

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -61,7 +61,12 @@ test('logical (deep test, find scoped)', function (t) {
   }).catch(t.threw);
 });
 
-test('deps - with uglify-package', function (t) {
+// fixture uglify-package does not exist, and newer versions of npm care
+const legacyNpm = Number(
+  require('child_process').execSync('npm -v').toString().split('.', 1)[0]
+) < 5;
+
+legacyNpm && test('deps - with uglify-package', function (t) {
   resolveTree(uglifyfixture).then(function (res) {
     t.equal(res.name, 'uglify-package', 'package name matches');
     t.type(res.dependencies, 'object', 'has dependencies');


### PR DESCRIPTION
- add nodejs 8 runtime to test matrix
- use default installed npm version for each nodejs version
- skip tests against non-existent npm package for npm >= 5
- remove coveralls webhook
