### PR TITLE
Feat: `noFromArrays` option to not include `from` arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ resolveDeps(process.cwd(), options).then(function (tree) {
 - options (optional)
   - dev: [default, `false`] report only development options
   - extraFields: [default, `undefined`] extract extra fields from dependencies' package.json files. example: `['files']`
-  - dontIncludeFromArrays: [default, `false`] don't include `from` arrays with list of deps from `root` on every node
+  - noFromArrays: [default, `false`] don't include `from` arrays with list of deps from `root` on every node
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ resolveDeps(process.cwd(), options).then(function (tree) {
 - options (optional)
   - dev: [default, `false`] report only development options
   - extraFields: [default, `undefined`] extract extra fields from dependencies' package.json files. example: `['files']`
+  - dontIncludeFromArrays: [default, `false`] don't include `from` arrays with list of deps from `root` on every node
 
 ## How it works
 

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -95,6 +95,10 @@ function logicalTree(fileTree, options) {
   logicalRoot.unique = unique.bind(null, logicalRoot);
   logicalRoot.problems = problems.slice(0);
 
+  if (options.dontIncludeFromArrays) {
+    logicalRoot = removeFromPaths(logicalRoot);
+  }
+
   return logicalRoot;
 }
 
@@ -180,3 +184,15 @@ function copy(leaf, from) {
 
   return res;
 }
+
+function removeFromPaths(tree) {
+  delete tree.from;
+
+  var deps = tree.dependencies;
+  Object.keys(deps).forEach(function (name) {
+    removeFromPaths(deps[name]);
+  });
+
+  return tree;
+}
+

--- a/lib/logical.js
+++ b/lib/logical.js
@@ -95,7 +95,7 @@ function logicalTree(fileTree, options) {
   logicalRoot.unique = unique.bind(null, logicalRoot);
   logicalRoot.problems = problems.slice(0);
 
-  if (options.dontIncludeFromArrays) {
+  if (options.noFromArrays) {
     logicalRoot = removeFromPaths(logicalRoot);
   }
 

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -127,8 +127,12 @@ test('end to end (this package __without__ dev)', function (t) {
 });
 
 test('end to end (this package wihtout from arrays)', function (t) {
-  lib(__dirname + '/../', {dontIncludeFromArrays: true})
+  lib(__dirname + '/../', {noFromArrays: true})
   .then(function (res) {
+    var from = ['snyk-resolve-deps', 'tap', 'nyc', 'istanbul', 'handlebars', 'uglify-js', 'source-map'];
+    var plucked = res.pluck(from, 'source-map', '~0.5.1');
+    t.ok(plucked.name, 'source-map');
+
     var unique = res.unique();
     var counter = {};
     lib.walk(unique, function (dep) {

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -125,3 +125,23 @@ test('end to end (this package __without__ dev)', function (t) {
   .catch(t.threw)
   .then(t.end);
 });
+
+test('end to end (this package wihtout from arrays)', function (t) {
+  lib(__dirname + '/../', {dontIncludeFromArrays: true})
+  .then(function (res) {
+    var unique = res.unique();
+    var counter = {};
+    lib.walk(unique, function (dep) {
+      if (dep.from) {
+        t.fail('from array found on node', dep);
+      }
+      if (counter[dep.full]) {
+        counter[dep.full]++;
+        t.fail('found ' + dep.full + ' ' + counter[dep.full] + ' times in unique list');
+      }
+      counter[dep.full] = 1;
+    });
+  })
+  .catch(t.threw)
+  .then(t.end);
+});

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -47,7 +47,7 @@ test('logical (find devDeps)', function (t) {
 });
 
 test('logical (dont include from arrays)', function (t) {
-  resolveTree(rootfixtures, { dontIncludeFromArrays: true }).then(function (res) {
+  resolveTree(rootfixtures, { noFromArrays: true }).then(function (res) {
     var names = [];
     walk(res, function (dep) {
       if (dep.from) {

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -46,6 +46,21 @@ test('logical (find devDeps)', function (t) {
   }).catch(t.threw).then(t.end);
 });
 
+test('logical (dont include from arrays)', function (t) {
+  resolveTree(rootfixtures, { dontIncludeFromArrays: true }).then(function (res) {
+    var names = [];
+    walk(res, function (dep) {
+      if (dep.from) {
+        t.fail('from array found on node ', dep);
+      }
+      if (dep.depType === depTypes.DEV) {
+        names.push(dep.name);
+      }
+    });
+
+  }).catch(t.threw).then(t.end);
+});
+
 test('logical (deep test, find scoped)', function (t) {
   t.plan(1);
 

--- a/test/manual.js
+++ b/test/manual.js
@@ -1,0 +1,16 @@
+var resolve = require('../lib');
+
+function main() {
+  var target = process.argv[2];
+  var options = process.argv[3] || '{}';
+  options = JSON.parse(options);
+
+  resolve(target, options).then(function (result) {
+    console.log(JSON.stringify(result, null, 2));
+  }).catch(function (error) {
+    console.log('Error:', error.stack);
+  });
+
+};
+
+main();


### PR DESCRIPTION
Currently, every node in the resolved tree contains a `from` array, listing the path of the packages from the root to the node. This information might be useful, but is also redundant and can be easily reconstructed after the fact, if needed.

This new option lets the user get the result without `from` arrays on every node, resulting in a JSON tree that is ~2x smaller.

The default behavior remains intact so this is not a breaking change.