### PR TITLE
fix: added missing "file" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ resolveDeps(process.cwd(), options).then(function (tree) {
   - dev: [default, `false`] report only development options
   - extraFields: [default, `undefined`] extract extra fields from dependencies' package.json files. example: `['files']`
   - noFromArrays: [default, `false`] don't include `from` arrays with list of deps from `root` on every node
+  - file: [default, `'package.json'`] location of the package file
 
 ## How it works
 

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -21,18 +21,28 @@ function applyExtraFields(src, dest, extraFields) {
 // FIXME only supports dependancies & dev deps not opt-deps
 function loadModules(root, depType, options) {
   tryRequire.cache.reset(); // reset the package cache on re-run
+
+  var opt = _.clone(options || {});
+  var pkgRoot = root;
+
+  if (opt.file) {
+    var pathInfo = path.parse(opt.file);
+    pkgRoot = path.resolve(pkgRoot, pathInfo.dir);
+    opt.file = pathInfo.base;
+  }
+
   return loadModulesInternal(
-    root,
+    pkgRoot,
     depType || null,
     null,
-    options
+    opt
   ).then(function (tree) {
     // ensure there's no missing packages our known root deps
     var missing = [];
     if (tree.__dependencies) {
       Object.keys(tree.__dependencies).forEach(function (name) {
         if (!tree.dependencies[name]) {
-          missing.push(resolve(name, root).then(function (dir) {
+          missing.push(resolve(name, pkgRoot).then(function (dir) {
             return loadModulesInternal(dir, depTypes.PROD, {
               __from: [tree.name + '@' + tree.version, name],
             });
@@ -71,7 +81,7 @@ function loadModulesInternal(root, rootDepType, parent, options) {
   }
 
   var modules = {};
-  var dir = path.resolve(root, 'package.json');
+  var dir = path.resolve(root, options.file || 'package.json');
   // 1. read package.json for written deps
   var promise = tryRequire(dir).then(function (pkg) {
     // if there's a package found, collect this information too

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -1,4 +1,5 @@
 module.exports = {
+  clone: require('lodash.clone'),
   set: require('lodash.set'),
   get: require('lodash.get'),
   assign: require('lodash.assign'),

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "ansicolors": "^0.3.2",
     "debug": "^3.2.5",
+    "lodash.clone": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "lodash.assign": "^4.2.0",

--- a/test/deps.test.js
+++ b/test/deps.test.js
@@ -56,3 +56,17 @@ test('deps - throws without path', function (t) {
     t.equal(e.message, 'module path must be a string', 'error is correct');
   }).then(t.end);
 });
+
+test('deps - with relative "file" option', function (t) {
+  deps(__dirname, null, {
+    dev: true,
+    file: 'fixtures/pkg-undef-deps-with-modules/package.json',
+  })
+    .then(function (res) {
+      t.equal(res.dependencies.debug.depType, 'dev', 'debug is valid');
+      t.equal(res.dependencies.undefsafe.depType, 'extraneous',
+          'undefsafe is extraneous');
+    })
+    .catch(t.threw)
+    .then(t.end);
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Added "file" option witch allows to set `package.json` location path.

#### Where should the reviewer start?

Tests.

#### How should this be manually tested?

Using snyk CLI:

```
cd snyk/node_modules
rm -rf snyk-resolve-deps
ln -s ../../resolve-deps snyk-resolve-deps
cd ..
node dist/cli/index.js --file=../test-project-npm/package.json
```

#### What are the relevant tickets?

*Support relative path for npm/yarn projects*

While `snyk test --file=nestedFolder/pom.xml` works, `snyk test --file=nestedFolder/package.json` doesn't. We should support relative path for npm/yarn manifest files.

For the implementation, this would require parsing path for provided file option and using it as a prefix for manifest file / node_modules folder.

https://snyksec.atlassian.net/browse/SC-6274
