### PR TITLE
Skip tilde dir to prevent requiring itself

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -130,7 +130,9 @@ function loadModulesInternal(root, rootDepType, parent, options) {
     return fs.readdir(path.resolve(root, 'node_modules')).then(function (dirs) {
       var res = dirs.map(function (dir) {
         // completely ignore `.bin` npm helper dir
-        if (dir === '.bin' || dir === '.DS_Store') {
+        // ~ can be a symlink to node_modules itself
+        // (https://www.npmjs.com/package/link-tilde)
+        if (['.bin', '.DS_Store', '~'].indexOf(dir) >= 0) {
           return null;
         }
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
While generating dependency tree, `node_modules` folder is walked recursively to indentify all the items. Symlink called `~` can appear inside `node_modules` pointing to `node_modules` itself (e.g. https://www.npmjs.com/package/link-tilde). 

When this happens, program fails because it cannot handle this self-reference. Skipping `~` directory doesn't do any harm, because `~` cannot be used as a package name and rest of `node_modules` is traversed anyway.


