### PR TITLE
feat: get rid of @types/package-lock by moving used type into code

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -9,8 +9,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import * as resolve from 'snyk-resolve';
 import * as tryRequire from 'snyk-try-require';
-import { AbbreviatedVersion } from 'package-json';
-import { PackageExpanded, PackageJsonEnriched } from './types';
+import { AbbreviatedVersion, PackageExpanded, PackageJsonEnriched } from './types';
 
 const debug = debugModule('snyk:resolve:deps');
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,3 @@
-import { AbbreviatedVersion } from "package-json";
-
 export type DepType = 'extraneous' | 'optional'| 'prod' | 'dev';
 
 export interface DepSpecDict {
@@ -8,6 +6,27 @@ export interface DepSpecDict {
 
 export interface DepExpandedDict {
     [name: string]: PackageExpanded;
+}
+
+export interface AbbreviatedVersion {
+    readonly name: string;
+    readonly version: string;
+    readonly dist: {
+        readonly shasum: string;
+        readonly tarball: string;
+        readonly integrity?: string;
+    };
+    readonly deprecated?: string;
+    readonly dependencies?: {readonly [name: string]: string};
+    readonly optionalDependencies?: {readonly [name: string]: string};
+    readonly devDependencies?: {readonly [name: string]: string};
+    readonly bundleDependencies?: {readonly [name: string]: string};
+    readonly peerDependencies?: {readonly [name: string]: string};
+    readonly bin?: {readonly [key: string]: string};
+    readonly directories?: readonly string[];
+    readonly engines?: {readonly [type: string]: string};
+    readonly _hasShrinkwrap?: boolean;
+    readonly [key: string]: unknown;
 }
 
 // Intermediate type used during parsing

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@types/node": "^6.14.4",
-    "@types/package-json": "^5.0.0",
     "@types/semver": "^5.5.0",
     "ansicolors": "^0.3.2",
     "debug": "^3.2.5",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Remove `@types/package-lock` from `dependencies` by moving one used type `AbbreviatedVersion` directly into code.