### PR TITLE
Fixes `link:.` triggering infinite loops

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -153,8 +153,14 @@ function loadModulesInternal(root, rootDepType, parent, options?): Promise<Packa
         }
 
         // otherwise try to load a package.json from this node_module dir
-        directory = path.resolve(root, 'node_modules', directory, 'package.json');
-        return tryRequire(directory) as AbbreviatedVersion;
+        directory = path.resolve(root, 'node_modules', directory);
+        return fs.realpath(directory).then(function (realDirectory) {
+          if (realDirectory === root) {
+            return null;
+          } else {
+            return tryRequire(path.resolve(directory, 'package.json'));
+          }
+        });
       });
 
       return Promise.all(res).then(function (response) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a bug when a project uses `"my-app": "link:."` inside its dependencies.

It does this by ensuring that we don't loop continuously on symlinks within `node_modules` that point to the original directory. I believe it's still possible to trigger infinite loops (for example with a symlink in `a/node_modules/b` pointing to `b`, and another in `b/node_modules/a` pointing to `a`, but the most problematic use case is covered).

cc @lirantal 

#### How should this be manually tested?

- Run `yarn policies set-version nightly` to fetch the latest Yarn build
- Run `yarn add my-app@link:.`
- Run `yarn add snyk`
- Run `yarn snyk monitor --file=package.json`

It shouldn't hang forever (note that `yarn snyk test` will still crash, but this one can be fixed in Yarn so that's what I'll do).

#### Any background context you want to provide?

We had to use a resolution override in our `package.json` to use my fork and avoid our CI OOMing.

#### Additional questions

Not sure I understand how the tests fixtures work so I haven't added one.