### PR TITLE
feat(technically-breaking): make logicalTree async

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -22,8 +22,8 @@ function applyExtraFields(src, dest, extraFields) {
   });
 }
 
-// FIXME only supports dependancies & dev deps not opt-deps
-function loadModules(root, depType, options) {
+// FIXME only supports dependencies & dev deps not opt-deps
+async function loadModules(root, depType, options): Promise<PackageExpanded> {
   tryRequire.cache.reset(); // reset the package cache on re-run
 
   let opt = _.clone(options || {});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,8 +6,9 @@ import pluck = require('./pluck');
 import unique = require('./unique');
 import { Options, LogicalRoot } from './types';
 
-function resolveDeps(dir: string, options: Options): Promise<LogicalRoot> {
-  return physicalTree(dir, null, options).then((res) => logicalTree(res, options));
+async function resolveDeps(dir: string, options: Options): Promise<LogicalRoot> {
+  const physical = await physicalTree(dir, null, options);
+  return await logicalTree(physical, options);
 }
 
 resolveDeps.physicalTree = physicalTree;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,7 +73,7 @@ export interface PackageExpanded {
 export interface LogicalRoot extends PackageExpanded {
     numFileDependencies: number;
     numDependencies: number;
-    unique: () => PackageExpanded;
+    unique: () => Promise<PackageExpanded>;
     pluck: (path: string[], name: string, range: string) => false | PackageExpanded;
 }
 

--- a/lib/unique.ts
+++ b/lib/unique.ts
@@ -4,13 +4,14 @@ export = unique;
 import walk = require('./walk');
 import { PackageExpanded } from './types';
 
-function unique(deps: PackageExpanded) {
+async function unique(deps: PackageExpanded): Promise<PackageExpanded> {
   let res = copy(deps);
   res.dependencies = {};
 
-  walk(deps, function (dep) {
+  await walk(deps, async (dep) => {
     let shallowCopy = copy(dep);
     res.dependencies[dep.name + '@' + dep.version] = shallowCopy;
+    return false;
   });
 
   return res;

--- a/lib/walk.ts
+++ b/lib/walk.ts
@@ -3,17 +3,18 @@ import { DepExpandedDict, PackageExpanded } from "./types";
 // TODO(kyegupov): avoid default exports
 export = walk;
 
-function walk(depsOrPkg: PackageExpanded | DepExpandedDict, filter) {
+async function walk(depsOrPkg: PackageExpanded | DepExpandedDict,
+                    filter: (deps, name?, allDeps?) => Promise<boolean>): Promise<void> {
   if (!depsOrPkg) {
-    return [];
+    return;
   }
 
   let deps = ((depsOrPkg as PackageExpanded).dependencies ? depsOrPkg.dependencies : depsOrPkg) as DepExpandedDict;
 
-  Object.keys(deps).forEach(function (name) {
-    let res = filter(deps[name], name, deps);
+  for (const name of Object.keys(deps)) {
+    let res = await filter(deps[name], name, deps);
     if (!res && deps[name] && deps[name].dep) {
-      walk(deps[name].dependencies, filter);
+      await walk(deps[name].dependencies, filter);
     }
-  });
+  }
 }

--- a/test/end-to-end.test.js
+++ b/test/end-to-end.test.js
@@ -45,8 +45,8 @@ test('end to end (no deps)', function (t) {
   .then(t.end);
 });
 
-test('end to end (sub-pluck finds correctly)', function (t) {
-  let res = lib.logicalTree(require(__dirname + '/fixtures/oui.json'));
+test('end to end (sub-pluck finds correctly)', async (t) => {
+  let res = await lib.logicalTree(require(__dirname + '/fixtures/oui.json'));
   let from = [ 'foo@1.0.0',
     'chokidar@1.4.1',
     'fsevents@1.0.7',
@@ -105,37 +105,36 @@ test('end to end (bundle with dev)', function (t) {
   .then(t.end);
 });
 
-test('end to end (this package __without__ dev)', function (t) {
-  lib(__dirname + '/fixtures/bundle')
-  .then(function (res) {
+test('end to end (this package __without__ dev)', async (t) => {
+  const res = await lib(__dirname + '/fixtures/bundle');
+  {
     let from = ['bundle', 'tap', 'nyc', 'istanbul-reports', 'handlebars', 'uglify-js', 'source-map'];
     let plucked = res.pluck(from, 'source-map', '~0.6.1');
     t.ok(plucked.name, 'source-map');
 
     let unique = res.unique();
     let counter = {};
-    lib.walk(unique, function (dep) {
+    await lib.walk(unique, function (dep) {
       if (counter[dep.full]) {
         counter[dep.full]++;
         t.fail('found ' + dep.full + ' ' + counter[dep.full] + ' times in unique list');
       }
       counter[dep.full] = 1;
     });
-  })
-  .catch(t.threw)
-  .then(t.end);
+  }
+  t.end();
 });
 
-test('end to end (bundle without from arrays)', function (t) {
-  lib(__dirname + '/fixtures/bundle', {noFromArrays: true})
-  .then(function (res) {
+test('end to end (bundle without from arrays)', async (t) => {
+  const res = await lib(__dirname + '/fixtures/bundle', {noFromArrays: true})
+  {
     let from = ['bundle', 'tap', 'nyc', 'istanbul-reports', 'handlebars', 'uglify-js', 'source-map'];
     let plucked = res.pluck(from, 'source-map', '~0.6.1');
     t.ok(plucked.name, 'source-map');
 
     let unique = res.unique();
     let counter = {};
-    lib.walk(unique, function (dep) {
+    await lib.walk(unique, function (dep) {
       if (dep.from) {
         t.fail('from array found on node', dep);
       }
@@ -145,7 +144,6 @@ test('end to end (bundle without from arrays)', function (t) {
       }
       counter[dep.full] = 1;
     });
-  })
-  .catch(t.threw)
-  .then(t.end);
+  }
+  t.end();
 });

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -30,23 +30,26 @@ test('logical (flags missing module)', function (t) {
   }).catch(t.threw).then(t.end);
 });
 
-test('logical (find devDeps)', function (t) {
+test('logical (find devDeps)', async (t) => {
   let devDeps = Object.keys(require(path.resolve(bundleFixture, 'package.json')).devDependencies);
-  resolveTree(bundleFixture, { dev: true }).then(function (res) {
+  const res = await resolveTree(bundleFixture, { dev: true });
+  {
     let names = [];
-    walk(res, function (dep) {
+    await walk(res, function (dep) {
       if (dep.depType === depTypes.DEV) {
         names.push(dep.name);
       }
     });
     t.deepEqual(names, devDeps, 'found the right devDeps');
-  }).catch(t.threw).then(t.end);
+  }
+  t.end();
 });
 
-test('logical (dont include from arrays)', function (t) {
-  resolveTree(bundleFixture, { noFromArrays: true }).then(function (res) {
+test('logical (dont include from arrays)', async (t) => {
+  const res = await resolveTree(bundleFixture, { noFromArrays: true });
+  {
     let names = [];
-    walk(res, function (dep) {
+    await walk(res, function (dep) {
       if (dep.from) {
         t.fail('from array found on node ', dep);
       }
@@ -54,23 +57,24 @@ test('logical (dont include from arrays)', function (t) {
         names.push(dep.name);
       }
     });
-
-  }).catch(t.threw).then(t.end);
+  }
+  t.end();
 });
 
-test('logical (deep test, find scoped)', function (t) {
+test('logical (deep test, find scoped)', async (t) => {
   t.plan(1);
 
   // note: the @remy/vuln-test is actually found in the parent directory
   // when running in npm@3, so this is the real test
-  resolveTree(npm3fixture).then(function (res) {
+  const res = await resolveTree(npm3fixture);
+  {
     // console.log(tree(res));
-    walk(res.dependencies, function (dep) {
+    await walk(res.dependencies, function (dep) {
       if (dep.name === '@remy/vuln-test') {
         t.pass('found scopped dependency');
       }
     });
-  }).catch(t.threw);
+  }
 });
 
 // fixture uglify-package does not exist, and newer versions of npm care
@@ -90,12 +94,13 @@ legacyNpm && test('deps - with uglify-package', function (t) {
 
 });
 
-test('logical (deep test, expecting extraneous)', function (t) {
+test('logical (deep test, expecting extraneous)',  async (t) => {
   // note: the @remy/vuln-test is actually found in the parent directory
   // when running in npm@3, so this is the real test
-  resolveTree(bundleFixture, { dev: true }).then(function (res) {
+  const res = await resolveTree(bundleFixture, { dev: true });
+  {
     let extraneous = [];
-    walk(res.dependencies, function (dep) {
+    await walk(res.dependencies, function (dep) {
       if (dep.extraneous) {
         extraneous.push(dep.name);
       }
@@ -114,13 +119,15 @@ test('logical (deep test, expecting extraneous)', function (t) {
     const count = extraneous.length;
     t.ok(count === 6 || count === 5,
       'found ' + count + ' extraneous packages: ' + extraneous.join(', '));
-  }).catch(t.threw).then(t.end);
+  }
+  t.end();
 });
 
-test('logical (find semver multiple times)', function (t) {
-  resolveTree(npm3fixture).then(function (res) {
+test('logical (find semver multiple times)', async (t) => {
+  const res = await resolveTree(npm3fixture);
+  {
     let names = [];
-    walk(res.dependencies, function (dep) {
+    await walk(res.dependencies, function (dep) {
       names.push(dep.name);
     });
     let count = names.filter(function (f) {
@@ -130,18 +137,20 @@ test('logical (find semver multiple times)', function (t) {
     // around in, so the dependency is missing. It's not a good way to run this
     // test.
     t.ok(1 === count || 2 === count, 'expecting 1 or 2 semvers, not ' + count);
-  }).catch(t.threw).then(t.end);
+  }
+  t.end();
 });
 
-test('logical (deep copies)', function (t) {
-  let res = logicalTree(hawkpkg);
+test('logical (deep copies)', async (t) => {
+  let res = await logicalTree(hawkpkg);
   let deps = [];
   let paths = {};
-  walk(res, function (dep) {
+  await walk(res, function (dep) {
     if (dep.name === 'hawk') {
       deps.push(dep);
       paths[dep.from] = 1;
     }
+    return false;
   });
 
   t.equal(deps.length, 5, 'found 5 instance');

--- a/test/prune.test.js
+++ b/test/prune.test.js
@@ -2,7 +2,7 @@ let test = require('tap-only');
 let prune = require('../lib/prune');
 let walk = require('../lib/walk');
 
-test('prune (search for hawk)', function (t) {
+test('prune (search for hawk)', async (t) => {
   let fixture = require('./fixtures/prune.json');
 
   prune(fixture, function (dep) {
@@ -10,7 +10,7 @@ test('prune (search for hawk)', function (t) {
   });
 
   let count = 0;
-  walk(fixture, function (dep) {
+  await walk(fixture, function (dep) {
     if (!Object.keys(dep.dependencies).length) {
       count++;
     }

--- a/test/unique.test.js
+++ b/test/unique.test.js
@@ -2,13 +2,13 @@ let test = require('tap-only');
 let unique = require('../lib/unique');
 let walk = require('../lib/walk');
 
-test('unique', function (t) {
+test('unique', async (t) => {
   let fixture = require('./fixtures/out.json');
   let names = [];
 
-  let res = unique(fixture);
+  let res = await unique(fixture);
 
-  walk(res, function (dep) {
+  await walk(res, function (dep) {
     names.push(dep.full);
   });
 

--- a/test/walk.test.js
+++ b/test/walk.test.js
@@ -1,11 +1,11 @@
 let test = require('tap-only');
 let walk = require('../lib/walk');
 
-test('walk (search for semver)', function (t) {
+test('walk (search for semver)', async (t) => {
   let fixture = require('./fixtures/out.json');
   let names = [];
 
-  walk(fixture, function (dep) {
+  await walk(fixture, function (dep) {
     names.push(dep.name);
   });
 


### PR DESCRIPTION
#### What does this PR do?

Follows #60, please resolve that first.

Make `logicalTree` and `walk` `async`.

This will have some performance impact, but also will allow us not to hold up the whole event loop for extended periods of time.