### PR TITLE
feat: @types are not prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "author": "Remy Sharp",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/node": "^6.14.4",
+    "@types/semver": "^5.5.0",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3",
     "tap": "^12.6.0",
@@ -32,8 +34,6 @@
     "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "@types/node": "^6.14.4",
-    "@types/semver": "^5.5.0",
     "ansicolors": "^0.3.2",
     "debug": "^3.2.5",
     "lodash.assign": "^4.2.0",


### PR DESCRIPTION
#### What does this PR do?

`@types` packages are only needed at compile time. `typescript` is a `devDependency`, so I'm reasonably sure we're not compiling with only prod deps installed, so this can definitely be a `devDependency`.

Aiming to reduce bundle size for `snyk/snyk`.