### PR TITLE
feat: upgrade debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ansicolors": "^0.3.2",
-    "debug": "^3.2.5",
+    "debug": "^4.1.1",
     "lodash.assign": "^4.2.0",
     "lodash.assignin": "^4.2.0",
     "lodash.clone": "^4.5.0",


### PR DESCRIPTION
Old version drops support for node 4 and 5, which doesn't
affect us all that much.
