### PR TITLE
Move postinstall command to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,12 @@
     "build": "tsc",
     "build-watch": "tsc -w",
     "tslint": "tslint --project tsconfig.json --format stylish --exclude **/src/**/*.js",
-    "prepare": "npm run build",
+    "prepare": "npm run build && npm --prefix test/fixtures/bundle install",
     "lint": "npm run tslint",
     "check-tests": "! grep 'test.only' test/*.test.js -n",
     "env": "node -e 'console.log(process.env, process.versions)'",
     "cover": "jest test/*.test.js  --collectCoverage",
-    "test": "npm run check-tests && npm run lint && jest test/*.test.[jt]s",
-    "postinstall": "npm --prefix test/fixtures/bundle install"
+    "test": "npm run check-tests && npm run lint && jest test/*.test.[jt]s"
   },
   "author": "Remy Sharp",
   "license": "Apache-2.0",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Moves the `npm --prefix test/fixtures/bundle install` from the `postinstall` script to the `prepare` script so that it does not break when installing it as a package using npm@7.

#### Any background context you want to provide?
We're using npm@7 for CLI builds now and this is causing errors on `npm install`.

