### PR TITLE
feat: peer deps now get tagged as such when building tree

### DIFF
--- a/lib/dep-types.ts
+++ b/lib/dep-types.ts
@@ -7,26 +7,30 @@ import { DepType, HasDependencySpecs } from "./types";
 // extraneous means not found in package.json files, prod means not dev ATM
 function depTypes(depName: string, pkg: HasDependencySpecs) {
   let type: string | null = null;
-  let from = 'unknown';
+  let from = "unknown";
 
-  if (pkg.devDependencies && pkg.devDependencies[depName]) {
+  if (pkg.devDependencies?.[depName]) {
     type = depTypes.DEV;
     from = pkg.devDependencies[depName];
   }
 
-  if (pkg.optionalDependencies && pkg.optionalDependencies[depName]) {
+  if (pkg.peerDependencies?.[depName]) {
+    type = depTypes.PEER;
+    from = pkg.peerDependencies[depName];
+  }
+
+  if (pkg.optionalDependencies?.[depName]) {
     type = depTypes.OPTIONAL;
     from = pkg.optionalDependencies[depName];
   }
 
   // production deps trump all
-  if (pkg.dependencies && pkg.dependencies[depName]) {
+  if (pkg.dependencies?.[depName]) {
     type = depTypes.PROD;
     from = pkg.dependencies[depName];
   }
 
-  let bundled = !!(pkg.bundleDependencies &&
-    pkg.bundleDependencies[depName]);
+  let bundled = !!(pkg.bundleDependencies && pkg.bundleDependencies[depName]);
 
   return {
     type: type as string,
@@ -35,10 +39,11 @@ function depTypes(depName: string, pkg: HasDependencySpecs) {
   };
 }
 
-depTypes.EXTRANEOUS = 'extraneous' as DepType;
-depTypes.OPTIONAL = 'optional' as DepType;
-depTypes.PROD = 'prod' as DepType;
-depTypes.DEV = 'dev' as DepType;
+depTypes.EXTRANEOUS = "extraneous" as DepType;
+depTypes.OPTIONAL = "optional" as DepType;
+depTypes.PEER = "peer" as DepType;
+depTypes.PROD = "prod" as DepType;
+depTypes.DEV = "dev" as DepType;
 
 // TODO(kyegupov): switch to plain exports
 export = depTypes;

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -106,6 +106,7 @@ function loadModulesInternal(root, rootDepType, parent, options?): Promise<Packa
         __devDependencies: pkg.devDependencies,
         __dependencies: pkg.dependencies,
         __optionalDependencies: pkg.optionalDependencies,
+        __peerDependencies: pkg.peerDependencies,
         __bundleDependencies: pkg.bundleDependencies,
         __filename: pkg.__filename,
       });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,17 @@
-import physicalTree = require('./deps');
-import logicalTree = require('./logical');
-import walk = require('./walk');
-import prune = require('./prune');
-import pluck = require('./pluck');
-import unique = require('./unique');
-import { Options, LogicalRoot } from './types';
+import physicalTree = require("./deps");
+import logicalTree = require("./logical");
+import walk = require("./walk");
+import prune = require("./prune");
+import pluck = require("./pluck");
+import unique = require("./unique");
+import { Options, LogicalRoot } from "./types";
 
-function resolveDeps(dir: string, options: Options): Promise<LogicalRoot> {
-  return physicalTree(dir, null, options).then((res) => logicalTree(res, options));
+async function resolveDeps(
+  dir: string,
+  options: Options,
+): Promise<LogicalRoot> {
+  const physTree = await physicalTree(dir, null, options);
+  return logicalTree(physTree, options);
 }
 
 resolveDeps.physicalTree = physicalTree;

--- a/lib/logical.ts
+++ b/lib/logical.ts
@@ -126,7 +126,7 @@ function walkDeps(root: PackageExpanded, tree: PackageExpanded, suppliedFrom: st
   let deps = _assignIn({}, tree.__dependencies,
     tree.__from && from.length === 1 ? tree.__devDependencies : {});
 
-  deps = _assignIn(deps, tree.__optionalDependencies);
+  deps = _assignIn(deps, tree.__optionalDependencies, tree.__peerDependencies);
 
   return Object.keys(deps).reduce(function walkDepsPicker(acc, curr) {
     // only attempt to walk this dep if it's not in our path already
@@ -148,6 +148,7 @@ function walkDeps(root: PackageExpanded, tree: PackageExpanded, suppliedFrom: st
           devDependencies: tree.__devDependencies,
           bundleDependencies: tree.__bundleDependencies,
           optionalDependencies: tree.__optionalDependencies,
+          peerDependencies: tree.__peerDependencies,
         });
 
         pkg.depType = info.type as DepType;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,85 +1,92 @@
-export type DepType = 'extraneous' | 'optional'| 'prod' | 'dev';
+export type DepType = "extraneous" | "peer" | "optional" | "prod" | "dev";
 
 export interface DepSpecDict {
-    [name: string]: string;
+  [name: string]: string;
 }
 
 export interface DepExpandedDict {
-    [name: string]: PackageExpanded;
+  [name: string]: PackageExpanded;
 }
 
 export interface AbbreviatedVersion {
-    readonly name: string;
-    readonly version: string;
-    readonly dist: {
-        readonly shasum: string;
-        readonly tarball: string;
-        readonly integrity?: string;
-    };
-    readonly deprecated?: string;
-    readonly dependencies?: {readonly [name: string]: string};
-    readonly optionalDependencies?: {readonly [name: string]: string};
-    readonly devDependencies?: {readonly [name: string]: string};
-    readonly bundleDependencies?: {readonly [name: string]: string};
-    readonly peerDependencies?: {readonly [name: string]: string};
-    readonly bin?: {readonly [key: string]: string};
-    readonly directories?: readonly string[];
-    readonly engines?: {readonly [type: string]: string};
-    readonly _hasShrinkwrap?: boolean;
-    readonly [key: string]: unknown;
+  readonly name: string;
+  readonly version: string;
+  readonly dist: {
+    readonly shasum: string;
+    readonly tarball: string;
+    readonly integrity?: string;
+  };
+  readonly deprecated?: string;
+  readonly dependencies?: { readonly [name: string]: string };
+  readonly optionalDependencies?: { readonly [name: string]: string };
+  readonly devDependencies?: { readonly [name: string]: string };
+  readonly bundleDependencies?: { readonly [name: string]: string };
+  readonly peerDependencies?: { readonly [name: string]: string };
+  readonly bin?: { readonly [key: string]: string };
+  readonly directories?: readonly string[];
+  readonly engines?: { readonly [type: string]: string };
+  readonly _hasShrinkwrap?: boolean;
+  readonly [key: string]: unknown;
 }
 
 // Intermediate type used during parsing
 export interface PackageJsonEnriched extends AbbreviatedVersion {
-    full: string;
-    __from: string[];
-    shrinkwrap: any;
+  full: string;
+  __from: string[];
+  shrinkwrap: any;
 }
 
 export interface HasDependencySpecs {
-    readonly dependencies?: {readonly [name: string]: string};
-    readonly optionalDependencies?: {readonly [name: string]: string};
-    readonly devDependencies?: {readonly [name: string]: string};
-    readonly bundleDependencies?: {readonly [name: string]: string};
+  readonly dependencies?: { readonly [name: string]: string };
+  readonly peerDependencies?: { readonly [name: string]: string };
+  readonly optionalDependencies?: { readonly [name: string]: string };
+  readonly devDependencies?: { readonly [name: string]: string };
+  readonly bundleDependencies?: { readonly [name: string]: string };
 }
 
 // Similar to package-json.AbbreviatedVersion, but with deps expanded
 export interface PackageExpanded {
-    name: string;
-    version: string;
-    dep: string; // this is the npm version range spec that was resolved to `version`
-    license: string;
-    depType: DepType;
-    hasDevDependencies: boolean;
-    full: string;
-    __from: string[];
-    from?: string[]; // TODO(kyegupov): find out why both __from and from are used
-    __devDependencies: DepSpecDict;
-    __dependencies: DepSpecDict;
-    __optionalDependencies: DepSpecDict;
-    __bundleDependencies: DepSpecDict;
-    __filename: string;
-    devDependencies: DepExpandedDict;
-    dependencies: DepExpandedDict;
-    optionalDependencies: DepExpandedDict;
-    bundleDependencies: DepExpandedDict;
-    shrinkwrap: any;
-    bundled: any;
-    __used?: boolean;
-    problems?: string[];
-    extraneous?: boolean;
+  name: string;
+  version: string;
+  dep: string; // this is the npm version range spec that was resolved to `version`
+  license: string;
+  depType: DepType;
+  hasDevDependencies: boolean;
+  full: string;
+  __from: string[];
+  from?: string[]; // TODO(kyegupov): find out why both __from and from are used
+  __devDependencies: DepSpecDict;
+  __dependencies: DepSpecDict;
+  __optionalDependencies: DepSpecDict;
+  __peerDependencies: DepSpecDict;
+  __bundleDependencies: DepSpecDict;
+  __filename: string;
+  devDependencies: DepExpandedDict;
+  dependencies: DepExpandedDict;
+  optionalDependencies: DepExpandedDict;
+  peerDependencies: DepExpandedDict;
+  bundleDependencies: DepExpandedDict;
+  shrinkwrap: any;
+  bundled: any;
+  __used?: boolean;
+  problems?: string[];
+  extraneous?: boolean;
 }
 
 export interface LogicalRoot extends PackageExpanded {
-    numFileDependencies: number;
-    numDependencies: number;
-    unique: () => PackageExpanded;
-    pluck: (path: string[], name: string, range: string) => false | PackageExpanded;
+  numFileDependencies: number;
+  numDependencies: number;
+  unique: () => PackageExpanded;
+  pluck: (
+    path: string[],
+    name: string,
+    range: string,
+  ) => false | PackageExpanded;
 }
 
 export interface Options {
-    dev?: boolean; // report only development options
-    extraFields?: string[]; // extract extra fields from dependencies' package.json files. example: `['files']`
-    noFromArrays?: boolean; // don't include `from` arrays with list of deps from `root` on every node
-    file?: string; //  location of the package file
+  dev?: boolean; // report only development options
+  extraFields?: string[]; // extract extra fields from dependencies' package.json files. example: `['files']`
+  noFromArrays?: boolean; // don't include `from` arrays with list of deps from `root` on every node
+  file?: string; //  location of the package file
 }


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This change means that a dependency included as a peerDep no longer gets tracked as `extraneous` and instead is tracked as `peer`, functionality wise the code has not changed.

#### Behaviour 

test | before | after
--------|--------|--------
npm <= 6 && no peer deps | No change to projects with no peer deps | No change to projects with no peer deps
npm 7+ && no peer deps | No change to projects with no peer deps | No change to projects with no peer deps
npm <= 6 && peer deps | If peer deps present they were tagged as extraneous | Now peer deps tagged as new type `peer`
npm 7+ && peer deps |  If peer deps present they were tagged as extraneous | Now peer deps tagged as new type `peer`