### PR TITLE
feat: add npm scope [CSENG-94]

### DIFF
--- a/lib/dep-labels.ts
+++ b/lib/dep-labels.ts
@@ -1,0 +1,30 @@
+import * as depTypes from "./dep-types";
+import { DepType, NpmScope, PackageExpanded, Options, PackageLabels } from "./types";
+
+export function withPackageLabels(
+  pkg: PackageExpanded,
+  options: Options,
+): PackageLabels | undefined {
+  if (!options.showNpmScope) {
+    return undefined;
+  }
+
+  const scope = getNpmScope(pkg.depType);
+
+  return {
+    "npm:scope": scope,
+  };
+}
+
+export function getNpmScope(depType: DepType): NpmScope {
+  switch (depType) {
+    case depTypes.DEV:
+      return "dev";
+    case depTypes.PROD:
+      return "prod";
+    case depTypes.EXTRANEOUS:
+    case depTypes.OPTIONAL:
+    default:
+      return "unknown";
+  }
+}

--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -13,7 +13,8 @@ import * as path from 'path';
 import * as semver from 'semver';
 import * as resolve from 'snyk-resolve';
 import { tryRequirePackageJson, cache as tryRequireCache } from './try-require';
-import { AbbreviatedVersion, PackageExpanded, PackageJsonEnriched } from './types';
+import { AbbreviatedVersion, PackageExpanded } from './types';
+import { withPackageLabels } from './dep-labels';
 
 const debug = debugModule('snyk:resolve:deps');
 
@@ -127,6 +128,11 @@ function loadModulesInternal(root, rootDepType, parent, options?): Promise<Packa
       if (modules.__from.length === 0) {
         modules.__from.push(full);
       }
+
+      const rootLabels = withPackageLabels(modules, options);
+      if (rootLabels) {
+        modules.labels = rootLabels;
+      }
     } else {
       throw new Error(dir + ' is not a node project');
     }
@@ -220,6 +226,11 @@ function loadModulesInternal(root, rootDepType, parent, options?): Promise<Packa
 
           if (pkg.shrinkwrap) {
             acc[curr.name!].shrinkwrap = pkg.shrinkwrap;
+          }
+
+          const depLabels = withPackageLabels(acc[curr.name!], options);
+          if (depLabels) {
+            acc[curr.name!].labels = depLabels;
           }
 
           return acc;

--- a/lib/logical.ts
+++ b/lib/logical.ts
@@ -11,6 +11,7 @@ import * as colour from 'ansicolors';
 import { parsePackageString as moduleToObject } from 'snyk-module';
 import * as util from 'util';
 import { PackageExpanded, DepType, Options, LogicalRoot, DepExpandedDict } from './types';
+import { withPackageLabels } from './dep-labels';
 
 const format = util.format;
 const ext = colour.bgBlack(colour.green('extraneous'));
@@ -39,7 +40,7 @@ function logicalTree(fileTree: PackageExpanded, options: Options) {
 
   let problems: string[] = [];
   let logicalRoot = copy(fileTree, fileTree.__from) as LogicalRoot;
-  logicalRoot.dependencies = walkDeps(fileTree, fileTree, undefined, problems);
+  logicalRoot.dependencies = walkDeps(fileTree, fileTree, undefined, problems, options);
 
   let removedPaths: string[][] = [];
 
@@ -80,10 +81,23 @@ function logicalTree(fileTree: PackageExpanded, options: Options) {
       problems.push(issue);
       leaf.extraneous = true;
       leaf.depType = depTypes.EXTRANEOUS;
-      leaf.dependencies = walkDeps(fileTree, dep, undefined, problems);
+
+      const leafLabels = withPackageLabels(leaf, options);
+
+      if (leafLabels) {
+        leaf.labels = leafLabels;
+      }
+
+      leaf.dependencies = walkDeps(fileTree, dep, undefined, problems, options);
       walk(leaf.dependencies, function (extraDep) {
         extraDep.extraneous = true;
         extraDep.depType = depTypes.EXTRANEOUS;
+
+        const extraDepLabels = withPackageLabels(extraDep, options);
+
+        if (extraDepLabels) {
+          extraDep.labels = extraDepLabels;
+        }
       });
       insertLeaf(logicalRoot, leaf, dep.__from);
     }
@@ -119,7 +133,7 @@ function insertLeaf(tree, leaf, from) {
 }
 
 function walkDeps(root: PackageExpanded, tree: PackageExpanded, suppliedFrom: string[] | undefined,
-                  problems: string[]): DepExpandedDict {
+                  problems: string[], options: Options): DepExpandedDict {
   let from = suppliedFrom || tree.__from;
 
   // only include the devDeps on the root level package
@@ -153,11 +167,17 @@ function walkDeps(root: PackageExpanded, tree: PackageExpanded, suppliedFrom: st
         pkg.depType = info.type as DepType;
         pkg.dep = info.from;
 
+        const pkgLabels = withPackageLabels(pkg, options);
+
+        if (pkgLabels) {
+          pkg.labels = pkgLabels;
+        }
+
         if (tree.bundled) { // carry the bundled flag down from the parent
           dep.bundled = pkg.bundled = tree.bundled;
         }
 
-        pkg.dependencies = walkDeps(root, dep, pkg.from, problems);
+        pkg.dependencies = walkDeps(root, dep, pkg.from, problems, options);
       }
     }
 
@@ -181,6 +201,11 @@ function copy(leaf: PackageExpanded, from?: string[]): PackageExpanded {
 
   res.from = from.slice(0);
   res.__filename = leaf.__filename;
+
+  // Preserve labels if they exist
+  if (leaf.labels) {
+    res.labels = leaf.labels;
+  }
 
   return res;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,12 @@ export interface HasDependencySpecs {
     readonly bundleDependencies?: {readonly [name: string]: string};
 }
 
+export type NpmScope = 'prod' | 'dev' | 'unknown';
+
+export interface PackageLabels {
+    'npm:scope': NpmScope;
+}
+
 // Similar to package-json.AbbreviatedVersion, but with deps expanded
 export interface PackageExpanded {
     name: string;
@@ -68,6 +74,7 @@ export interface PackageExpanded {
     __used?: boolean;
     problems?: string[];
     extraneous?: boolean;
+    labels?: PackageLabels;
 }
 
 export interface LogicalRoot extends PackageExpanded {
@@ -82,4 +89,5 @@ export interface Options {
     extraFields?: string[]; // extract extra fields from dependencies' package.json files. example: `['files']`
     noFromArrays?: boolean; // don't include `from` arrays with list of deps from `root` on every node
     file?: string; //  location of the package file
+    showNpmScope?: boolean;
 }

--- a/test/logical.test.js
+++ b/test/logical.test.js
@@ -150,4 +150,119 @@ describe('logical.test.js', () => {
         expect(deps.length).toEqual(5);
         expect(Object.keys(paths).length).toEqual(5);
     });
+
+    test('GIVEN showNpmScope is false WHEN building logical tree THEN packages should not have labels', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: false, dev: true}).then(function (res) {
+            let hasLabels = false;
+            walk(res.dependencies, function (dep) {
+                if (dep.labels) {
+                    hasLabels = true;
+                }
+            });
+            expect(hasLabels).toBeFalsy();
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is undefined WHEN building logical tree THEN packages should not have labels', function (done) {
+        resolveTree(bundleFixture, {dev: true}).then(function (res) {
+            let hasLabels = false;
+            walk(res.dependencies, function (dep) {
+                if (dep.labels) {
+                    hasLabels = true;
+                }
+            });
+            expect(hasLabels).toBeFalsy();
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree with dev dependencies THEN dev dependencies should have npm:scope label set to dev', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true, dev: true}).then(function (res) {
+            let devDepsWithLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (dep.depType === depTypes.DEV) {
+                    expect(dep.labels).toBeDefined();
+                    expect(dep.labels['npm:scope']).toEqual('dev');
+                    devDepsWithLabels.push(dep.name);
+                }
+            });
+            expect(devDepsWithLabels.length).toBeGreaterThan(0);
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree with prod dependencies THEN prod dependencies should have npm:scope label set to prod', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true}).then(function (res) {
+            let prodDepsWithLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (dep.depType === depTypes.PROD) {
+                    expect(dep.labels).toBeDefined();
+                    expect(dep.labels['npm:scope']).toEqual('prod');
+                    prodDepsWithLabels.push(dep.name);
+                }
+            });
+            expect(prodDepsWithLabels.length).toBeGreaterThan(0);
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree with optional dependencies THEN optional dependencies should have npm:scope label set to unknown', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true}).then(function (res) {
+            let optionalDepsWithLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (dep.depType === depTypes.OPTIONAL) {
+                    expect(dep.labels).toBeDefined();
+                    expect(dep.labels['npm:scope']).toEqual('unknown');
+                    optionalDepsWithLabels.push(dep.name);
+                }
+            });
+            // Optional deps may or may not exist, so we just verify the structure if they do
+            if (optionalDepsWithLabels.length > 0) {
+                expect(optionalDepsWithLabels.length).toBeGreaterThan(0);
+            }
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree with extraneous dependencies THEN extraneous dependencies should have npm:scope label set to unknown', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true, dev: true}).then(function (res) {
+            let extraneousDepsWithLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (dep.extraneous && dep.depType === depTypes.EXTRANEOUS) {
+                    expect(dep.labels).toBeDefined();
+                    expect(dep.labels['npm:scope']).toEqual('unknown');
+                    extraneousDepsWithLabels.push(dep.name);
+                }
+            });
+            // Extraneous deps may or may not exist depending on npm version
+            if (extraneousDepsWithLabels.length > 0) {
+                expect(extraneousDepsWithLabels.length).toBeGreaterThan(0);
+            }
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree THEN all dependencies should have npm:scope labels', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true, dev: true}).then(function (res) {
+            let depsWithoutLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (!dep.labels || !dep.labels['npm:scope']) {
+                    depsWithoutLabels.push(dep.name);
+                }
+            });
+            expect(depsWithoutLabels.length).toEqual(0);
+        }).catch(fail).then(done);
+    });
+
+    test('GIVEN showNpmScope is true WHEN building logical tree THEN nested dependencies should also have npm:scope labels', function (done) {
+        resolveTree(bundleFixture, {showNpmScope: true, dev: true}).then(function (res) {
+            let nestedDepsWithoutLabels = [];
+            walk(res.dependencies, function (dep) {
+                if (dep.dependencies) {
+                    Object.keys(dep.dependencies).forEach(function (nestedDepName) {
+                        let nestedDep = dep.dependencies[nestedDepName];
+                        if (!nestedDep.labels || !nestedDep.labels['npm:scope']) {
+                            nestedDepsWithoutLabels.push(nestedDep.name);
+                        }
+                    });
+                }
+            });
+            expect(nestedDepsWithoutLabels.length).toEqual(0);
+        }).catch(fail).then(done);
+    });
 })


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds support for npm scope labels on resolved dependency packages. When the `showNpmScope` option is enabled, packages in the dependency tree will be annotated with an `npm:scope` label that indicates their dependency classification:

- `dev` - for development dependencies
- `prod` - for production dependencies  
- `unknown` - for extraneous and optional dependencies

The feature is implemented through a new `dep-labels.ts` module that provides the `withPackageLabels()` function, which is integrated throughout the dependency resolution pipeline in both `deps.ts` (file tree) and `logical.ts` (logical tree) modules.

#### Where should the reviewer start?

1. **Start with the new module**: `lib/dep-labels.ts` - This contains the core logic for determining and assigning npm scope labels based on dependency types.

2. **Review type definitions**: `lib/types.ts` - Check the new `NpmScope` type, `PackageLabels` interface, and the `showNpmScope` option added to the `Options` interface.

3. **Integration points**: 
   - `lib/deps.ts` (lines 132-135, 231-234) - Where labels are added to root packages and dependencies in the file tree
   - `lib/logical.ts` (lines 85-89, 96-100, 170-174) - Where labels are added during logical tree construction, including for extraneous dependencies

4. **Test coverage**: `test/logical.test.js` (lines 154-267) - Comprehensive test suite covering all scenarios including edge cases.

#### How should this be manually tested?

1. **Test with `showNpmScope: true`**:
   ```javascript
   const resolveTree = require('./lib');
   const result = await resolveTree('./test/fixtures/bundle', { 
     showNpmScope: true, 
     dev: true 
   });
   
   // Verify all dependencies have labels
   // Verify dev dependencies have labels['npm:scope'] === 'dev'
   // Verify prod dependencies have labels['npm:scope'] === 'prod'
   // Verify extraneous and optional dependencies have labels['npm:scope'] === 'unknown'
   ```

2. **Test with `showNpmScope: false` or undefined**:
   ```javascript
   const result = await resolveTree('./test/fixtures/bundle', { 
     showNpmScope: false 
   });
   // Verify no packages have labels property
   ```

3. **Run the test suite**:
   ```bash
   npm test -- test/logical.test.js
   ```

4. **Test nested dependencies**: Verify that nested dependencies at all levels of the tree also receive appropriate labels when `showNpmScope: true`.

#### Any background context you want to provide?

This feature enables downstream consumers of the dependency tree to easily identify and filter packages based on their npm scope classification (dev vs prod). The implementation is opt-in via the `showNpmScope` option to maintain backward compatibility and avoid unnecessary overhead when labels are not needed.

The label assignment logic maps dependency types as follows:
- `DEV` → `"dev"`
- `PROD` → `"prod"`  
- `EXTRANEOUS` and `OPTIONAL` → `"unknown"`

Labels are preserved when copying package objects in the logical tree (see `copy()` function in `logical.ts`), ensuring they persist through the tree transformation process.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CSENG-94

#### Screenshots

N/A

#### Additional questions

None
