### PR TITLE
fix: resolve 1 security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "ansicolors": "^0.3.2",
     "debug": "^4.3.4",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "lru-cache": "^4.1.5",
     "semver": "^5.7.2",
     "snyk-module": "^3.2.0",


### PR DESCRIPTION
# 🔒 Security Vulnerability Fixes

This PR addresses 1 security vulnerabilities detected by Snyk.

## ✅ Fixed Vulnerabilities

- **high** - Arbitrary Code Injection (CVE-2026-4800)
  - Upgraded from ^4.17.21 to ^4.18.1

**Reason:** lodash is a direct dependency; bumping the minimum version to 4.18.1 ensures the vulnerable version range (<=4.17.23) is no longer resolvable, as 4.18.1 is the latest release and contains the fix

**Dependency Path:**
- `snyk-resolve-deps > lodash`
